### PR TITLE
Change docs to cr-like

### DIFF
--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -30,9 +30,9 @@ After we aligned FASTQ files using selective alignment to the `splici` index, we
 1. During the [`generate-permit-list` step of `alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/generate_permit_list.html), we used the `--unfiltered-pl` option, which returns any cell with at least 1 read found in a reference barcode list. 
 For our reference barcode list, we used a list of all possible cell barcodes from 10X Genomics.
 
-2. We chose to use the `cr-like-em` resolution strategy for [feature quantification and UMI de-duplication](https://alevin-fry.readthedocs.io/en/latest/quant.html). 
-Similar to the way Cell Ranger performs feature quantification, the `cr-like-em` resolution strategy assigns all UMIs that align to a single gene to that gene. 
-In contrast to Cell Ranger, `cr-like-em` keeps multi-mapped reads and invokes an extra step to assign these multi-mapped reads to a UMI.
+2. We chose to use the `cr-like` resolution strategy for [feature quantification and UMI de-duplication](https://alevin-fry.readthedocs.io/en/latest/quant.html). 
+Similar to the way Cell Ranger performs feature quantification, the `cr-like` resolution strategy assigns all UMIs that align to a single gene to that gene.
+In the case of UMIs with reads that map to more than one gene, UMIs are assigned to the gene with the highest count for the UMI, and discarded in the case of a tie.
 
 ### Post alevin-fry processing
 


### PR DESCRIPTION
This is a small PR to reflect the fact that processing that we have actually been using is `cr-like` only. 