### PR TITLE
Describe what genes are included in the reference transcriptome

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -15,6 +15,7 @@ introns
 Kaminow
 Pearson
 pre
+pseudogenes
 Lun
 repo
 scpca

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -6,10 +6,12 @@ barcodes
 benchmarking
 cDNA
 de
+Ensembl
 et
 FASTQ
 Genomics
 github
+GRCh
 intronic
 introns
 Kaminow

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,7 +22,7 @@ Recent reports from others support our findings.
 
 #### What genes are included in the reference transcriptome? 
 
-The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment included 60,319 genes.
-The reference transcriptome was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/5dc49ffdcdb5c74dca86b0b79878f4d060029a53/bin/make_splici_fasta.R)).
-In addition to protein-coding genes, this reference transcriptome index includes pseudogenes and non-coding RNA. 
-Although there are 60,319 genes that are present in the reference transcriptome index, it is likely that many of these genes will not be detected in any given library.
+The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/5dc49ffdcdb5c74dca86b0b79878f4d060029a53/bin/make_splici_fasta.R)).
+The resulting reference transcriptome index included 60,319 genes.
+In addition to protein-coding genes, this list of genes includes pseudogenes and non-coding RNA.
+The gene expression data files available for download report all possible genes present in the reference transcriptome, even if not detected in a given library. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,3 +19,10 @@ We also compared the mean gene expression reported for each gene by both methods
 Recent reports from others support our findings. 
 [He _et al._ (2021)](https://doi.org/10.1101/2021.06.29.450377)) demonstrated that Alevin-fry can process single-cell and single-nuclei data more quickly and efficiently then other available methods, while also decreasing the false positive rate of gene detection that is commonly seen in methods that utilize transcriptome alignment.
 [You _et al._ (2021)](https://doi.org/10.1101/2021.06.17.448895) and [Tian _et al._ (2019)](https://doi.org/10.1038/s41592-019-0425-8) have also noted that results from different pre-processing workflows for single-cell RNA-sequencing analysis tend to result in compatible results downstream.
+
+#### What genes are included in the reference transcriptome? 
+
+The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment included 60,319 genes.
+The reference transcriptome was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the script used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/5dc49ffdcdb5c74dca86b0b79878f4d060029a53/bin/make_splici_fasta.R)).
+Although there are 60,319 genes that are present in the reference transcriptome index, it is likely that many of these genes will not be detected in any given library.
+In addition to protein-coding genes, this reference transcriptome index includes pseudogenes and non-coding RNA.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,6 +23,6 @@ Recent reports from others support our findings.
 #### What genes are included in the reference transcriptome? 
 
 The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment included 60,319 genes.
-The reference transcriptome was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the script used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/5dc49ffdcdb5c74dca86b0b79878f4d060029a53/bin/make_splici_fasta.R)).
+The reference transcriptome was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/5dc49ffdcdb5c74dca86b0b79878f4d060029a53/bin/make_splici_fasta.R)).
+In addition to protein-coding genes, this reference transcriptome index includes pseudogenes and non-coding RNA. 
 Although there are 60,319 genes that are present in the reference transcriptome index, it is likely that many of these genes will not be detected in any given library.
-In addition to protein-coding genes, this reference transcriptome index includes pseudogenes and non-coding RNA.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,7 +37,7 @@ scpca_sample <- readRDS("SCPCL000000_filtered.rds")
 
 #### What genes are included in the reference transcriptome? 
 
-The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/5dc49ffdcdb5c74dca86b0b79878f4d060029a53/bin/make_splici_fasta.R)).
-The resulting reference transcriptome index included 60,319 genes.
+The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/v0.1.1/bin/make_splici_fasta.R)).
+The resulting reference transcriptome index contains 60,319 genes.
 In addition to protein-coding genes, this list of genes includes pseudogenes and non-coding RNA.
 The gene expression data files available for download report all possible genes present in the reference transcriptome, even if not detected in a given library. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,7 +35,7 @@ scpca_sample <- readRDS("SCPCL000000_filtered.rds")
 
 ## What is the difference between a sample and a library?
 
-#### What genes are included in the reference transcriptome? 
+## What genes are included in the reference transcriptome? 
 
 The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly GRCh38, Ensembl database version 104 ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/v0.1.1/bin/make_splici_fasta.R)).
 The resulting reference transcriptome index contains 60,319 genes.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,7 +37,7 @@ scpca_sample <- readRDS("SCPCL000000_filtered.rds")
 
 #### What genes are included in the reference transcriptome? 
 
-The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/v0.1.1/bin/make_splici_fasta.R)).
+The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly GRCh38, Ensembl database version 104 ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/v0.1.1/bin/make_splici_fasta.R)).
 The resulting reference transcriptome index contains 60,319 genes.
 In addition to protein-coding genes, this list of genes includes pseudogenes and non-coding RNA.
 The gene expression data files available for download report all possible genes present in the reference transcriptome, even if not detected in a given library. 


### PR DESCRIPTION
Here I am adding in a FAQ addressing what type of genes are included in the index, #23. While doing this, I also included a link to the code used to generate the reference transcriptome used to make the splici index (addressing #12). I kept this pretty short and mentioned the number of genes and that they include protein-coding genes, pseudogenes, and non-coding genes. I also put in a brief sentence that the output files they receive will include all genes regardless of if they are detected or not. 

One thing I was wondering was if we want to add in a statement that we suggest removing any genes that are not detected or have mean gene expression of 0 before doing analysis or do we just leave that alone and not include anything on suggestions yet? 

In general I didn't go into too much detail and kept this brief, but let me know if there was more detail that you think I should be providing. 

Closes #23 
Closes #12 