### PR TITLE
FAQ for difference between sample and library ID

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -12,7 +12,7 @@ _add in illustration of file structure for sample downloads_
 
 Sample folders (indicated by the `SCPCS` prefix) contain the files for all libraries (`SCPCL` prefix) derived from that biological sample. 
 Most samples only have one library that has been sequenced. 
-See the {ref}`FAQ section about samples and libraries <faq:what is the difference between a sample and a library?>` for more information.
+See the {ref}`FAQ section about samples and libraries <faq:What is the difference between participants, samples, and libraries?>` for more information.
 
 The files associated with each library are (example shown for a library with ID `SCPCL000000`):
 - An unfiltered counts file: `SCPCL000000_unfiltered.rds`, 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,7 +40,7 @@ A sample ID, labeled as `scpca_sample_id` and indicated by the prefix `SCPCS`, r
 For example, one participant may have a sample collected both at initial diagnosis and at relapse.
 This would result in two unique sample ID's with the same participant ID. 
 
-The library ID, labeled as `scpca_library_id` and indicated by the prefix `SCPCL`, represents a single emulsion and droplet generation using the 10X Genomics worfklow from a given sample. 
+The library ID, labeled as `scpca_library_id` and indicated by the prefix `SCPCL`, represents a single emulsion and droplet generation using the 10X Genomics workflow from a given sample. 
 In most cases, each sample will only have one corresponding library.
 However, in some cases multiple libraries underwent separate droplet generation and sequencing from the same sample, resulting in more than one library ID being associated with the same sample ID. 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,7 +33,16 @@ library(SingleCellExperiment)
 scpca_sample <- readRDS("SCPCL000000_filtered.rds")
 ```
 
-## What is the difference between a sample and a library?
+## What is the difference between participants, samples, and libraries?
+
+The `participant_id` indicates the participant, or patient, from which a sample, or collection of samples, is obtained from. 
+A sample ID, labeled as `scpca_sample_id` and indicated by the prefix `SCPCS`, represents a unique tissue that was collected from a participant. 
+For example, one participant can have a sample collected both at initial diagnosis and at relapse.
+This would result in two unique sample ID's with the same participant ID. 
+
+The library ID, labeled as `scpca_library_id` and indicated by the prefix `SCPCL`, represents a single emulsion and droplet generation using the 10X worfklow from a given sample. 
+In most cases, each sample will only have one corresponding library.
+However, in some cases multiple libraries underwent separate droplet generation and sequencing from the same sample, resulting in multiple library ID's being associated with the same sample ID. 
 
 ## What genes are included in the reference transcriptome? 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,12 +37,12 @@ scpca_sample <- readRDS("SCPCL000000_filtered.rds")
 
 The `participant_id` indicates the participant, or patient, from which a sample, or collection of samples, is obtained from. 
 A sample ID, labeled as `scpca_sample_id` and indicated by the prefix `SCPCS`, represents a unique tissue that was collected from a participant. 
-For example, one participant can have a sample collected both at initial diagnosis and at relapse.
+For example, one participant may have a sample collected both at initial diagnosis and at relapse.
 This would result in two unique sample ID's with the same participant ID. 
 
-The library ID, labeled as `scpca_library_id` and indicated by the prefix `SCPCL`, represents a single emulsion and droplet generation using the 10X worfklow from a given sample. 
+The library ID, labeled as `scpca_library_id` and indicated by the prefix `SCPCL`, represents a single emulsion and droplet generation using the 10X Genomics worfklow from a given sample. 
 In most cases, each sample will only have one corresponding library.
-However, in some cases multiple libraries underwent separate droplet generation and sequencing from the same sample, resulting in multiple library ID's being associated with the same sample ID. 
+However, in some cases multiple libraries underwent separate droplet generation and sequencing from the same sample, resulting in more than one library ID being associated with the same sample ID. 
 
 ## What genes are included in the reference transcriptome? 
 


### PR DESCRIPTION
Closes #28. I added in the text for the FAQ on explaining the difference between samples and libraries in the portal. While doing this, I thought it might be helpful to also include participant ID's in the discussion as I was having trouble explaining what a sample was without talking about participants. 

I'm not quite confident on the explanation of a library here for the audience of the portal but I'm assuming that most people would be generally familiar with the single-cell workflow. So I chose to refer to the different libraries as separate emulsions and droplet generations, which made the most sense to me. Definitely open to other suggestions on how best to explain this! 

Because I changed the header of this FAQ, I also had to update the link in the download section. This PR is also stacked on #30, since I was adding more to the same FAQ section and wanted to make conflict resolution down the line easier, so that will need to be reviewed first. 