### PR TITLE
Add FAQ on how to convert the SCE objects to Seurat objects

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,15 +81,8 @@ library(SingleCellExperiment)
 # read in RDS file 
 sce <- readRDS("SCPCL000000_filtered.rds")
 
-# grab counts matrix from SingleCellExperiment needed to build the Seurat Object
-counts <- counts(sce)
-
-# colData and rowData will need to be converted to a data.frame to be used in the Seurat object
-cell_metadata <- as.data.frame(colData(sce))
-row_metadata <- as.data.frame(rowData(sce))
-
-# create seurat object 
-seurat_object <- CreateSeuratObject(counts = counts, 
+# create seurat object from the SCE counts matrix
+seurat_object <- CreateSeuratObject(counts = counts(sce), 
                                     assay = "RNA",
                                     project = "SCPCL000000")
 ```
@@ -97,7 +90,7 @@ The above code will only maintain information found in the original counts matri
 Optionally, if you would like to keep the included cell and gene associated metadata during conversion to the Seurat object you can perform the below additional steps: 
 
 ```
-# colData and rowData will need to be converted to a data.frame to be used in the Seurat object
+# convert colData and rowData to data.frame for use in the Seurat object
 cell_metadata <- as.data.frame(colData(sce))
 row_metadata <- as.data.frame(rowData(sce))
 
@@ -111,19 +104,15 @@ seurat_object[["RNA"]]@meta.features <- row_metadata
 seurat_object@misc <- metadata(sce)
 ```
 
-In order to convert `SingleCellExperiment` objects from libraries that have counts from both RNA-sequencing and CITE-seq, you can use the following additional commands.
-This adds a second assay containing the CITE-seq counts and associated feature data to an existing Seurat object:
+For `SingleCellExperiment` objects from libraries with both RNA-seq and CITE-seq data, you can use the following additional commands to add a second assay containing the CITE-seq counts and associated feature data:
 
 ```
 # create assay object in Seurat from CITE-seq counts found in altExp(SingleCellExperiment)
-cite_counts <- counts(altExp(sce))
-cite_assay <- CreateAssayObject(counts = cite_counts)
-
-# optional: convert rowData to data.frame for use in Seurat object
-cite_row_metadata <- as.data.frame(rowData(altExp(sce)))
+cite_assay <- CreateAssayObject(counts = counts(altExp(sce)))
 
 # optional: add row metadata (rowData) from altExp to assay 
-cite_assay@meta.features = cite_row_metadata
+cite_row_metadata <- as.data.frame(rowData(altExp(sce)))
+cite_assay@meta.features <- cite_row_metadata
 
 # add altExp from SingleCellExperiment as second assay to Seurat
 seurat_object[["CITE"]] <- cite_assay

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -93,7 +93,7 @@ seurat_object <- CreateSeuratObject(counts = counts,
                                     assay = "RNA",
                                     project = "SCPCL000000")
 ```
-The above code will only maintain information found in the original counts matrix from the SingleCellExperiment.
+The above code will only maintain information found in the original counts matrix from the `SingleCellExperiment`.
 Optionally, if you would like to keep the included cell and gene associated metadata during conversion to the Seurat object you can perform the below additional steps: 
 
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,12 +61,12 @@ You can find the [function for generating a QC report](https://github.com/AlexsL
 
 ## What if I want to use Seurat instead of Bioconductor? 
 
-The files available for download contain [`SingleCellExperiment objects`](http://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html). 
-These can easily be converted into Seurat objects. 
+The files available for download contain [`SingleCellExperiment` objects](http://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html). 
+If desired, these can be converted into Seurat objects. 
 
 You will need to [install and load the `Seurat` package](https://satijalab.org/seurat/articles/install.html) to work with Seurat objects.
 
-For libraries that only contain RNA-sequencing data (i.e. do not have a CITE-seq library found in the `altExp` of the `SingleCellExperiment object`), you can use the following commands:
+For libraries that only contain RNA-sequencing data (i.e. do not have a CITE-seq library found in the `altExp` of the `SingleCellExperiment` object), you can use the following commands:
 
 ```
 library(Seurat)
@@ -86,6 +86,7 @@ seurat_object[["RNA"]]@meta.features <- as.data.frame(rowData(sce))
 # add metadata from SingleCellExperiment to Seurat
 seurat_object@misc <- metadata(sce)
 ```
+
 In order to convert `SingleCellExperiment` objects from libraries that have counts from both RNA-sequencing and CITE-seq, you can use the following additional commands.
 This adds a second assay containing the CITE-seq counts and associated feature data to an existing Seurat object:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,12 +70,14 @@ For libraries that only contain RNA-sequencing data (i.e. do not have a CITE-seq
 
 ```
 library(Seurat)
+library(SingleCellExperiment)
 
 # grab counts matrix from the SingleCellExperiment
-counts <- as.matrix(counts(sce))
+counts <- counts(sce)
 
 # create seurat object 
-seurat_object <- CreateSeuratObject(counts = counts, assay = "RNA",
+seurat_object <- CreateSeuratObject(counts = counts, 
+                                    assay = "RNA",
                                     project = "project_name",
                                     # add colData from SingleCellExperiment
                                     meta.data = as.data.frame(colData(sce)))

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -86,7 +86,7 @@ seurat_object[["RNA"]]@meta.features <- as.data.frame(rowData(sce))
 seurat_object@misc <- metadata(sce)
 ```
 In order to convert `SingleCellExperiment` objects from libraries that have counts from both RNA-sequencing and CITE-seq, you can use the following additional commands.
-This adds a second assay containing the CITE-seq counts and associated feature data to the existing Seurat object:
+This adds a second assay containing the CITE-seq counts and associated feature data to an existing Seurat object:
 
 ```
 # create assay object in Seurat from CITE-seq counts found in altExp(SingleCellExperiment)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,18 +78,26 @@ For libraries that only contain RNA-sequencing data (i.e. do not have a CITE-seq
 library(Seurat)
 library(SingleCellExperiment)
 
-# grab counts matrix from the SingleCellExperiment
+# read in RDS file 
+sce <- readRDS("SCPCL000000_filtered.rds")
+
+# grab elements from SingleCellExperiment needed to build the Seurat Object
 counts <- counts(sce)
+
+# colData and rowData will need to be converted to a data.frame to be used in the Seurat object
+cell_metadata <- as.data.frame(colData(sce))
+row_metadata <- as.data.frame(rowData(sce))
 
 # create seurat object 
 seurat_object <- CreateSeuratObject(counts = counts, 
                                     assay = "RNA",
-                                    project = "project_name",
-                                    # add colData from SingleCellExperiment
-                                    meta.data = as.data.frame(colData(sce)))
+                                    project = "SCPCL000000")
 
-# add rowData from SingleCellExperiment to Seurat 
-seurat_object[["RNA"]]@meta.features <- as.data.frame(rowData(sce))
+# add cell metadata (colData) from SingleCellExperiment to Seurat
+seurat_object@meta.data <- cell_metadata
+
+# add row metadata (rowData) from SingleCellExperiment to Seurat 
+seurat_object[["RNA"]]@meta.features <- row_metadata
 
 # add metadata from SingleCellExperiment to Seurat
 seurat_object@misc <- metadata(sce)
@@ -103,8 +111,11 @@ This adds a second assay containing the CITE-seq counts and associated feature d
 cite_counts <- counts(altExp(sce))
 cite_assay <- CreateAssayObject(counts = cite_counts)
 
-# add rowData from altExp to assay 
-cite_assay@meta.features = as.data.frame(rowData(altExp(sce)))
+# convert rowData to data.frame for use in Seurat object
+cite_row_metadata <- as.data.frame(rowData(altExp(sce)))
+
+# add row metadata (rowData) from altExp to assay 
+cite_assay@meta.features = cite_row_metadata
 
 # add altExp from SingleCellExperiment as second assay to Seurat
 seurat_object[["CITE"]] <- cite_assay

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,7 +81,7 @@ library(SingleCellExperiment)
 # read in RDS file 
 sce <- readRDS("SCPCL000000_filtered.rds")
 
-# grab elements from SingleCellExperiment needed to build the Seurat Object
+# grab counts matrix from SingleCellExperiment needed to build the Seurat Object
 counts <- counts(sce)
 
 # colData and rowData will need to be converted to a data.frame to be used in the Seurat object
@@ -92,6 +92,14 @@ row_metadata <- as.data.frame(rowData(sce))
 seurat_object <- CreateSeuratObject(counts = counts, 
                                     assay = "RNA",
                                     project = "SCPCL000000")
+```
+The above code will only maintain information found in the original counts matrix from the SingleCellExperiment.
+Optionally, if you would like to keep the included cell and gene associated metadata during conversion to the Seurat object you can perform the below additional steps: 
+
+```
+# colData and rowData will need to be converted to a data.frame to be used in the Seurat object
+cell_metadata <- as.data.frame(colData(sce))
+row_metadata <- as.data.frame(rowData(sce))
 
 # add cell metadata (colData) from SingleCellExperiment to Seurat
 seurat_object@meta.data <- cell_metadata
@@ -111,10 +119,10 @@ This adds a second assay containing the CITE-seq counts and associated feature d
 cite_counts <- counts(altExp(sce))
 cite_assay <- CreateAssayObject(counts = cite_counts)
 
-# convert rowData to data.frame for use in Seurat object
+# optional: convert rowData to data.frame for use in Seurat object
 cite_row_metadata <- as.data.frame(rowData(altExp(sce)))
 
-# add row metadata (rowData) from altExp to assay 
+# optional: add row metadata (rowData) from altExp to assay 
 cite_assay@meta.features = cite_row_metadata
 
 # add altExp from SingleCellExperiment as second assay to Seurat


### PR DESCRIPTION
Closes #26. Here I added in a section to address how to convert the SCE objects that we provide to Seurat objects. Right now I have only included how to work with the objects that contain RNA-seq data with/without CITE-seq data, but I'm anticipating that we would have to update these instructions for cell hashing data at a later date.

In order to do the conversion, I originally was going to use `as.Seurat()` which is suggested in the [vignette from Seurat](https://satijalab.org/seurat/archive/v3.1/conversion_vignette.html), however this requires normalized counts to be stored as `logcounts` in the sce object. Since we do not provide normalized sce objects, I tried a few ways around this, but then after some searching around realized that the best way to do this would probably be to grab the pieces from the sce and then build the Seurat object using `CreateSeuratObject()`. In doing this, I'm adding the `colData` to the `meta.data` of Seurat within the function, and then separately I needed to add in the `rowData` to the `meta.features` of the RNA object and the `metadata(sce)` to the `misc` of the Seurat object. 

I then included a section to add in the CITE-seq data. Here, I followed the [vignette on multi-modal data](https://satijalab.org/seurat/articles/multimodal_vignette.html#setup-a-seurat-object-add-the-rna-and-protein-data) to first create an additional assay, adding in the `rowData` for the CITE-seq separately to the `meta.features` slot first. Then I am adding that assay to the seurat object. 

One question I have for reviewers is that here I'm starting after reading in the RDS file, since we already have a FAQ to address that. Should I instead include the line to read in the RDS file? Or is it okay to start with the sce object already in the environment. 

Also noting that this PR is stacked on #32. 