### PR TITLE
epub fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 env
 
 # ignore local build directory
+_build/
 docs/_build/

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,4 +1,4 @@
-{%- extends "sphinx_rtd_theme/layout.html" %}
+{%- extends "!layout.html" %}
 {% block extrahead %}
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />


### PR DESCRIPTION
Readthedocs deploy is broken because it can't build the epub. This PR adds the `_build` directory to gitignore and fixes the issue by changing the theme path for extending `layout.html`