### PR TITLE
Update processing and filtering information in docs to reflect scpca-nf release 0.1.3

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -21,6 +21,7 @@ Pearson
 pre
 pseudogenes
 Lun
+miQC
 repo
 Rmarkdown
 scpca

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -48,7 +48,6 @@ For single-nuclei samples, all counts for spliced cDNA and intronic regions were
 In addition to an unfiltered counts matrix, we provide a matrix filtered to only cell barcodes from droplets that are likely to include true cells.
 To do this we used [`DropletUtils::emptyDropsCellRanger()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/emptyDropsCellRanger.html), a function that estimates the profile of cells containing ambient RNA and tests the likelihood of all other droplets as differing from the ambient profile [Lun _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y). 
 This function more closely mimics the filtering performed in Cell Ranger than it's predecessor [`DropletUtils::emptyDrops()`](https://www.bioconductor.org/packages/devel/bioc/vignettes/DropletUtils/inst/doc/DropletUtils.html#detecting-empty-droplets). 
-The ambient profile includes all droplets that have a rank between 45,000 - 90,000 in total UMI count.
 We consider droplets with an FDR less than or equal to 0.01 to be cell-containing droplets. 
 Only cells that pass this FDR threshold are included in the filtered counts matrix.
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -30,9 +30,9 @@ After mapping FASTQ files using selective alignment to the `splici` index, we co
 1. During the [`generate-permit-list` step of `alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/generate_permit_list.html), we used the `--unfiltered-pl` option, which returns any cell with at least 1 read found in a reference barcode list. 
 For our reference barcode list, we used a list of all possible cell barcodes from 10X Genomics.
 
-2. We chose to use the `cr-like` resolution strategy for [feature quantification and UMI de-duplication](https://alevin-fry.readthedocs.io/en/latest/quant.html). 
-Similar to the way Cell Ranger performs feature quantification, the `cr-like` resolution strategy assigns all UMIs that align to a single gene to that gene.
-In the case of UMIs with reads that map to more than one gene, UMIs are assigned to the gene with the highest count for the UMI, and discarded in the case of a tie.
+2. We chose to use the `cr-like-em` resolution strategy for [feature quantification and UMI de-duplication](https://alevin-fry.readthedocs.io/en/latest/quant.html). 
+Similar to the way Cell Ranger performs feature quantification, the `cr-like-em` resolution strategy assigns all UMIs that align to a single gene to that gene.
+In contrast to Cell Ranger, `cr-like-em` keeps multi-mapped reads and invokes an extra step to assign these multi-mapped reads to a UMI.
 
 3. With initial mapping to the `splici` index, `alevin-fry` quantification resulted in separate counts for spliced and unspliced transcripts, and an ambiguous count for reads compatible with either spliced or unspliced transcripts.
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -46,8 +46,9 @@ For single-nuclei samples, all counts for spliced cDNA and intronic regions were
 #### Filtering cells
 
 In addition to an unfiltered counts matrix, we provide a matrix filtered to only cell barcodes from droplets that are likely to include true cells.
-To do this we used [`DropletUtils::emptyDrops()`](https://www.bioconductor.org/packages/devel/bioc/vignettes/DropletUtils/inst/doc/DropletUtils.html#detecting-empty-droplets), a function that estimates the profile of cells containing ambient RNA and tests the likelihood of all other droplets as differing from the ambient profile [Lun _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y). 
-We defined the ambient profile to include all droplets with less than 200 UMI per cell by using the option `lower=200`.
+To do this we used [`DropletUtils::emptyDropsCellRanger()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/emptyDropsCellRanger.html), a function that estimates the profile of cells containing ambient RNA and tests the likelihood of all other droplets as differing from the ambient profile [Lun _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y). 
+This function more closely mimics the filtering performed in Cell Ranger than it's predecessor [`DropletUtils::emptyDrops()`](https://www.bioconductor.org/packages/devel/bioc/vignettes/DropletUtils/inst/doc/DropletUtils.html#detecting-empty-droplets). 
+The ambient profile includes all droplets that have a rank between 45,000 - 90,000 in total UMI count.
 We consider droplets with an FDR less than or equal to 0.01 to be cell-containing droplets. 
 Only cells that pass this FDR threshold are included in the filtered counts matrix.
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -47,7 +47,7 @@ For single-nuclei samples, all counts for spliced cDNA and intronic regions were
 
 In addition to an unfiltered counts matrix, we provide a matrix filtered to only cell barcodes from droplets that are likely to include true cells.
 To do this we used [`DropletUtils::emptyDropsCellRanger()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/emptyDropsCellRanger.html), a function that estimates the profile of cells containing ambient RNA and tests the likelihood of all other droplets as differing from the ambient profile [Lun _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y). 
-This function more closely mimics the filtering performed in Cell Ranger than it's predecessor [`DropletUtils::emptyDrops()`](https://www.bioconductor.org/packages/devel/bioc/vignettes/DropletUtils/inst/doc/DropletUtils.html#detecting-empty-droplets). 
+This function more closely mimics the filtering performed in Cell Ranger than its predecessor [`DropletUtils::emptyDrops()`](https://www.bioconductor.org/packages/devel/bioc/vignettes/DropletUtils/inst/doc/DropletUtils.html#detecting-empty-droplets). 
 We consider droplets with an FDR less than or equal to 0.01 to be cell-containing droplets. 
 Only cells that pass this FDR threshold are included in the filtered counts matrix.
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -51,7 +51,7 @@ These metrics were calculated by using [`miQC`](https://bioconductor.org/package
 | Column name             | Contents                                                                                                                                                                                      |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
-| `miQC_pass`             | Indicates the likelihood of cells passing the default miQC filtering threshold of 0.75, `TRUE` is assigned to cells that have a low probability of being compromised (i.e. less than 0.75)    |
+| `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells that have a low probability of being compromised (i.e. `prob_compromised` less than 0.75) and those with sufficiently low mitochondrial content (see [miQC vignette](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).)  |
 
 ### Gene information and metrics
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -51,7 +51,7 @@ These metrics were calculated by using [`miQC`](https://bioconductor.org/package
 | Column name             | Contents                                                                                                                                                                                      |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
-| `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells that have a low probability of being compromised, defined as cells with `prob_compromised` less than 0.75 and sufficiently low mitochondrial content (see [miQC vignette](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).)  |
+| `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).  |
 
 ### Gene information and metrics
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -51,7 +51,7 @@ These metrics were calculated by using [`miQC`](https://bioconductor.org/package
 | Column name             | Contents                                                                                                                                                                                      |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
-| `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells that have a low probability of being compromised (i.e. `prob_compromised` less than 0.75) and those with sufficiently low mitochondrial content (see [miQC vignette](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).)  |
+| `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells that have a low probability of being compromised, defined as cells with `prob_compromised` less than 0.75 and sufficiently low mitochondrial content (see [miQC vignette](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).)  |
 
 ### Gene information and metrics
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -43,9 +43,15 @@ The following per-cell data columns are included for each cell, calculated using
 | `subsets_mito_sum`      | UMI count of mitochondrial genes                                                                                                                                                              |
 | `subsets_mito_detected` | Number of mitochondrial genes detected                                                                                                                                                        |
 | `subsets_mito_percent`  | Percent of all UMI counts assigned to mitochondrial genes                                                                                                                                     |
-| `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html). Only present for `filtered` objects |
 | `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., CITE-seq)                                                                                                             |
 
+The following are additional per-cell data columns included only in `filtered` objects. 
+These metrics were calculated by using [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected to predict low-quality cells. 
+
+| Column name             | Contents                                                                                                                                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
+| `miQC_pass`             | Indicates the likelihood of cells passing the default miQC filtering threshold of 0.75, `TRUE` is assigned to cells that have a low probability of being compromised (i.e. less than 0.75)    |
 
 ### Gene information and metrics
 


### PR DESCRIPTION
Closes #45. Here I am updating the docs to reflect the most recent changes that will be present in the newest release of `scpca-nf`. There are three main points that I updated in the docs. 

1. Changing the resolution mode of alevin-fry to `cr-like-em`. Here I edited the docs to return to the original contents in which we use `cr-like-em` as the resolution for alevin-fry rather than `cr-like.`
2. Updating the discussion on `emptyDrops` filtering to be about `emptyDropsCellRanger`. Here I noted that we are using `emptyDropsCellRanger` and removed the mention of `lower` since that argument is no longer used in that function. I also added in a short discussion on how the ambient profile is calculated as that is one of the main differences between `emptyDrops` and `emptyDropsCellRanger`. Please let me know if this is not detailed enough and we should add more about this function here. 
3. Adding the `miQC_pass` column to the section on SCE file contents. Here, I updated the section that discusses the `colData` and decided to separate out what would be included in the filtered `colData` since those two columns are only present in filtered sces and both retain to miQC. Reviewers, let me know if you are okay with how I chose to break this up or would prefer the whole table to remain together? The other question I had here was if we should also include any guidance or cautions about using the `miQC_pass` column or leave it as is? 