### PR TITLE
Add information about hard UMI cutoff for filtering

### DIFF
--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -53,6 +53,9 @@ This function more closely mimics the filtering performed in Cell Ranger than it
 We consider droplets with an FDR less than or equal to 0.01 to be cell-containing droplets. 
 Only cells that pass this FDR threshold are included in the filtered counts matrix.
 
+In the event that the cells do not meet the assumptions met in `DropletUtils::emptyDropsCellRanger` and are unable to be filtered using this method (e.g. have a lower than expected number of droplets), droplets were filtered using a hard cutoff in the total number of UMI. 
+For these libraries, only droplets containing greater than 100 UMI are included in the filtered counts matrix.
+
 ## CITE-seq quantification
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -53,7 +53,7 @@ This function more closely mimics the filtering performed in Cell Ranger than it
 We consider droplets with an FDR less than or equal to 0.01 to be cell-containing droplets. 
 Only cells that pass this FDR threshold are included in the filtered counts matrix.
 
-In the event that the cells do not meet the assumptions met in `DropletUtils::emptyDropsCellRanger` and are unable to be filtered using this method (e.g. have a lower than expected number of droplets), droplets were filtered using a hard cutoff in the total number of UMI. 
+In the event that the cells do not meet the assumptions met in `DropletUtils::emptyDropsCellRanger` and are unable to be filtered using this method (e.g. have a lower than expected number of droplets), droplets were filtered based on total UMI count. 
 For these libraries, only droplets containing greater than 100 UMI are included in the filtered counts matrix.
 
 ## CITE-seq quantification

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -53,8 +53,8 @@ This function more closely mimics the filtering performed in Cell Ranger than it
 We consider droplets with an FDR less than or equal to 0.01 to be cell-containing droplets. 
 Only cells that pass this FDR threshold are included in the filtered counts matrix.
 
-In the event that the cells do not meet the assumptions met in `DropletUtils::emptyDropsCellRanger` and are unable to be filtered using this method (e.g. have a lower than expected number of droplets), droplets were filtered based on total UMI count. 
-For these libraries, only droplets containing greater than 100 UMI are included in the filtered counts matrix.
+For some libraries, `DropletUtils::emptyDropsCellRanger()` may fail due to low numbers of droplets with reads or other violations of its assumptions.
+For these libraries, only droplets containing at least 100 UMI are included in the filtered counts matrix.
 
 ## CITE-seq quantification
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -93,7 +93,8 @@ expt_metadata <- metadata(sce)
 | `tech_version`      | A string indicating the technology and version used for the single-cell library, such as 10Xv2, 10Xv3, or 10Xv3.1              |
 | `transcript_type`   | Transcripts included in gene counts: `spliced` for single-cell samples and `unspliced` for single-nuclei                       |
 | `miQC_model`        | The model object that `miQC` fit to the data and was used to calculate `prob_compromised`. Only present for `filtered` objects |
-
+| `filtering_method`  | Which method was used for filtering, one of `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. Only present for `filtered` objects |
+| `umi_cutoff`        | Only present if the `filtering_method` is `UMI cutoff`. The minimum number of UMI per cell used as a threshold for filtering. Only present for `filtered` objects.  |
 
 ## Additional `SingleCellExperiment` components for CITE-seq samples
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -93,8 +93,8 @@ expt_metadata <- metadata(sce)
 | `tech_version`      | A string indicating the technology and version used for the single-cell library, such as 10Xv2, 10Xv3, or 10Xv3.1              |
 | `transcript_type`   | Transcripts included in gene counts: `spliced` for single-cell samples and `unspliced` for single-nuclei                       |
 | `miQC_model`        | The model object that `miQC` fit to the data and was used to calculate `prob_compromised`. Only present for `filtered` objects |
-| `filtering_method`  | Which method was used for filtering, one of `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. Only present for `filtered` objects |
-| `umi_cutoff`        | Only present if the `filtering_method` is `UMI cutoff`. The minimum number of UMI per cell used as a threshold for filtering. Only present for `filtered` objects.  |
+| `filtering_method`  | The method used for cell filtering. One of `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. Only present for `filtered` objects |
+| `umi_cutoff`        | The minimum UMI count per cell used as a threshold for filtering. Only present for `filtered` objects where the `filtering_method` is `UMI cutoff` |
 
 ## Additional `SingleCellExperiment` components for CITE-seq samples
 


### PR DESCRIPTION
Closes #53. Here, I am adding a short note in the filtering section of the processing information to note that if a library does not meet the assumption of `emptyDropsCellRanger`, that it will be filtered using a hard cutoff instead. 

I also added in the additional fields in the metadata `filtering_method` and `umi_cutoff` to the `sce_file_contents` page. I chose to keep everything in the metadata for the sce as one large table, but thought about the idea of breaking out the three pieces of metadata that are only present for the filtered data and include in a small separate table below the first table (similar to how we do the `cell metrics` section). If reviewers like that idea, I can break out the table, but I wasn't sure if this was completely necessary. 

