### PR TITLE
Update illustrations for download files 

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -17,7 +17,7 @@ Every download also includes a single `single_cell_metadata.tsv` file containing
 The folder structure within the zip file is determined by whether individual samples or all samples associated with a project are selected for download.  
 
 ## Download folder structure for project downloads:
-![docs-downloads-project](https://user-images.githubusercontent.com/15315514/143308420-a3cca10d-814f-4c52-b934-98d5e9cef1c5.png)
+![docs-downloads-project](https://user-images.githubusercontent.com/15315514/156806533-f45e1bef-9a96-490d-b9ad-5aabec2d28a2.png)
 
 If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download. 
 The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
@@ -26,7 +26,7 @@ The `bulk_metadata.tsv` file contains associated metadata for all samples with b
 See also {ref}`processing bulk RNA samples <processing_information:Bulk RNA samples>`.   
 
 ## Download folder structure for individual sample downloads:
-![docs-downloads-sample](https://user-images.githubusercontent.com/15315514/143308436-715c03ec-fd39-45ba-8213-f24ca14ed0eb.png)
+![docs-downloads-sample](https://user-images.githubusercontent.com/15315514/156806534-7ef8d56b-f8f9-4458-b3f5-3f0f42cb7ede.png)
 
 ## Gene expression data
 


### PR DESCRIPTION
Closes #57. Here I incorporated the new illustrations that were created by @dvenprasad. I tested building the docs and looked to be sure that they appear as they are supposed to showing the new name for the `single_cell_metadata.tsv` file. 

I also stacked this on #56 so that we can merge all changes related to adding the bulk metadata together. 