### PR TITLE
Remove data available soon from bulk RNA-seq processing section

### DIFF
--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -85,8 +85,6 @@ See the 10X documentation for more information on how Space Ranger [quantifies g
 
 ## Bulk RNA samples 
 
-**_Data Available Soon_**
-
 ### Preprocessing with fastp
 
 Prior to quantifying gene expression for bulk RNA-seq samples, FASTQ files are pre-processed using [`fastp`](https://github.com/OpenGene/fastp) to perform adapter trimming, quality filtering, and length filtering. 


### PR DESCRIPTION
Closes #62. This PR removes the line in the processing information section that stated `data available soon` since we now have bulk data available on the portal. 