### PR TITLE
Update spatial download information to indicate spatial files will be separate

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -14,9 +14,6 @@ The files associated with each library are (example shown for a library with ID 
 
 Every download also includes a single `single_cell_metadata.tsv` file containing metadata for all libraries included in the download.
 
-If a sample includes a library that was processed using spatial transcriptomics, there will be an additional folder in the sample directory, `SCPCL000000_spatial`. 
-For more information about the contents of this folder, see the [spatial transcriptomics libraries section below](#spatial-transcriptomics-libraries). 
-
 The folder structure within the zip file is determined by whether individual samples or all samples associated with a project are selected for download.  
 
 ## Download folder structure for project downloads:
@@ -85,6 +82,8 @@ This file will contain fields equivalent to those found in the `single_cell_meta
 
 ## Spatial transcriptomics libraries
 
+If a sample includes a library processed using spatial transcriptomics, the spatial transcriptomics output files will be available as a separate download from single-cell/single-nuclei gene expression data and will only include spatial related files. 
+
 For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download. 
 Inside that folder will be the following folders and files: 
 
@@ -92,7 +91,10 @@ Inside that folder will be the following folders and files:
 - A `filtered_feature_bc_matrix` folder containing the [filtered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
 - A `spatial` folder containing [images and position information](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/images)
 - A `SCPCL000000_spaceranger_summary.html` file containing the [summary html report provided by Space Ranger](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/summary)
+- A `SCPCL000000_metadata.json` file containing library processing information. 
 
 A full description of all files included in the download for spatial transcriptomics libraries can also be found in the [`spaceranger count` documentation](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/using/count#outputs). 
+
+Every download also includes a single `spatial_metadata.tsv` file containing metadata for all libraries included in the download.
 
 _Coming Soon: Illustration of example download with spatial library_


### PR DESCRIPTION
Closes #67 and #69. 

Here I updated the download files section to reflect that the spatial libraries and single-cell/nuclei data will be available separately. To do that I removed mention of the spatial data in the beginning sections and then included a sentence at the beginning of the spatial specific section that stated the download would only contain spatial output files. Is this enough to indicate that they would be separate or should we make notes elsewhere in the text? 

I also updated the contents of the spatial download to include the `SCPCL000000_metadata.json` file as we [had indicated in our prior meetings](https://docs.google.com/document/d/1z8XwF7u7byPluDXPXKfYz0j4IhFNNaWzRWCH1-yiICA/edit). And then mentioned the inclusion of the `spatial_metadata.tsv` file which will be replacing the `single_cell_metadata.tsv` file. 