### PR TITLE
pinning jinga<3.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx==3.2.1
+jinja2<3.1.0
 sphinx_rtd_theme==1.0.0
 myst-parser==0.15.1
 livereload==2.6.3


### PR DESCRIPTION
The builds were broken because of a mismatch in dependency versions. This locks jinja under 3.1.0 so it should continue to build. If we upgrade Sphinx we will most likely just want to remove this.

* pinning jinga<3.1.0