### PR TITLE
Addition of Multiplex FAQs

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -18,6 +18,7 @@ deconvolved
 demultiplex
 demultiplexed
 demultiplexing
+demux
 Dobin
 DropletUtils
 Ensembl

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -57,6 +57,7 @@ scRNA
 splici
 Srivastava
 Stegle
+Stoeckius
 subdiagnosis
 Tian
 transcriptome

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,10 +66,11 @@ Downloading a multiplexed sample on the portal will result in obtaining the gene
 This means that users will receive the gene expression data for all samples that were combined into a given library and will have to separate any cells corresponding to the sample of interest before proceeding with downstream analysis.
 
 We have applied multiple {ref}`demultiplexing methods <processing_information:hto demultiplexing>` to multiplexed libraries and noticed that these demultiplexing methods can vary both in calls and confidence levels assigned. 
+[Here we have performed some exploratory analysis comparing demultiplexing methods within a single multiplexed library](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/alsf-scpca/blob/main/analysis/quantifier-comparisons/15-demux-comparisons.nb.html).
 Because of the inconsistency across demultiplexing methods used, the choice of demultiplexing method to use is up to the discretion of the user. 
 Rather than separating out each sample, the sample calls and any associated statistics regarding sample calls for multiple demultiplexing methods can be found in the `_filtered.rds` file for each multiplexed library. 
-We also include the Hash Tag Oligo counts matrix to allow demultiplexing using other available methods.
 See the {ref}`demultiplexing results section <sce_file_contents:demultiplexing results>` for instructions on how to access the demultiplexing results in the `SingleCellExperiment` objects for multiplexed libraries.
+We also include the Hash Tag Oligo counts matrix to allow demultiplexing using other available methods.
 
 ## What are estimated demux cell counts? 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -60,20 +60,25 @@ This means that a single library contains cells or nuclei that correspond to mul
 Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells or nuclei belong to which sample within a multiplexed library. 
 The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.  
 
+## Why are demultiplexed samples not available? 
+
+Downloading a multiplexed sample on the portal will result in obtaining the gene expression files corresponding to the library containing the chosen multiplexed sample and any other samples that were multiplexed with that chosen sample. 
+This means that users will receive the gene expression data for all samples that were combined into a given library and will have to separate any cells corresponding to the sample of interest before proceeding with downstream analysis.
+
+We have applied multiple {ref}`demultiplexing methods <processing_information:hto demultiplexing>` to multiplexed libraries and noticed that these demultiplexing methods assign different cell barcodes to each sample at varying confidence levels. 
+Because of the inconsistency across demultiplexing methods used, the choice of demultiplexing method to use is up to the discretion of the user. 
+Rather than separating out each sample, the sample calls and any associated statistics regarding sample calls for multiple demultiplexing methods can be found in the `_filtered.rds` file for each multiplexed library. 
+See the {ref}`demultiplexing results section <sce_file_contents:demultiplexing results>` for instructions on how to access the demultiplexing results in the `SingleCellExperiment` objects for multiplexed libraries.
+
 ## What are estimated demux cell counts? 
 
 Estimated demux cell counts are provided for multiplexed libraries and refer to the estimated cell counts for each sample that is present in the library. 
-Cells that are included in the estimated cell count are cells that can be confidently assigned to a given sample using a given demultiplexing method. 
+In order to provide an estimate of the number of cells or nuclei that are present in a given sample before download, we use the estimated number of cells per sample identified by one of the tested demultiplexing methods.
+However, these estimated demux cell counts simply represent an estimate and we encourage users to investigate the data on their own and make their own decisions on the best demultiplexing method to use for their research purposes. 
+
 Note that not all cells in a library are included in the estimated demux cell count, as some cells may not be able to be assigned to a particular sample. 
-For more about demultiplexing, see the section on {ref}`processing multiplexed libraries <processing_information:multiplexed libraries>`.
-
-## Why do multiplexed samples have estimated demux cell counts? 
-
 Estimated demux cell counts will only be reported for multiplexed samples and will not be reported for single-cell or single-nuclei samples that are not multiplexed. 
-This is because multiplexed samples have multiple samples combined into one library using cell hashing, and samples have not been separated or demultiplexed. 
-Because there are multiple accepted methods that can be used for demultiplexing, we provide the single multiplexed library with the sample calls from each method, rather than separating out each sample. 
-The {ref}`demultiplexing results <sce_file_contents:demultiplexing results>` can be found in the `SingleCellExperiment` objects for each multiplexed library. 
-The estimated demux cell counts simply represent an estimate of the number of cells per sample based on a single multiplexing method. 
+For more about demultiplexing, see the section on {ref}`processing multiplexed libraries <processing_information:multiplexed libraries>`.
 
 ## What genes are included in the reference transcriptome?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,9 +55,9 @@ Participant IDs are only present for samples that were derived from the same par
 
 ## What is a multiplexed sample? 
 
-Multiplexed samples refer to samples that have been combined together into one library using cell hashing and then sequenced together. 
-This means that a single library contains cells that correspond to multiple samples. 
-Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library. 
+Multiplexed samples refer to samples that have been combined together into a single library using cell hashing ([Stoeckius _et al._ 2018](https://doi.org/10.1186/s13059-018-1603-1)) or a related technology and then sequenced together. 
+This means that a single library contains cells or nuclei that correspond to multiple samples. 
+Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells or nuclei belong to which sample within a multiplexed library. 
 The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.  
 
 ## What are estimated demux cell counts? 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,19 +65,20 @@ The libraries available for download on the portal have not been separated by sa
 Downloading a multiplexed sample on the portal will result in obtaining the gene expression files corresponding to the library containing the chosen multiplexed sample and any other samples that were multiplexed with that chosen sample. 
 This means that users will receive the gene expression data for all samples that were combined into a given library and will have to separate any cells corresponding to the sample of interest before proceeding with downstream analysis.
 
-We have applied multiple {ref}`demultiplexing methods <processing_information:hto demultiplexing>` to multiplexed libraries and noticed that these demultiplexing methods assign different cell barcodes to each sample at varying confidence levels. 
+We have applied multiple {ref}`demultiplexing methods <processing_information:hto demultiplexing>` to multiplexed libraries and noticed that these demultiplexing methods can vary both in calls and confidence levels assigned. 
 Because of the inconsistency across demultiplexing methods used, the choice of demultiplexing method to use is up to the discretion of the user. 
 Rather than separating out each sample, the sample calls and any associated statistics regarding sample calls for multiple demultiplexing methods can be found in the `_filtered.rds` file for each multiplexed library. 
+We also include the Hash Tag Oligo counts matrix to allow demultiplexing using other available methods.
 See the {ref}`demultiplexing results section <sce_file_contents:demultiplexing results>` for instructions on how to access the demultiplexing results in the `SingleCellExperiment` objects for multiplexed libraries.
 
 ## What are estimated demux cell counts? 
 
 Estimated demux cell counts are provided for multiplexed libraries and refer to the estimated cell counts for each sample that is present in the library. 
 In order to provide an estimate of the number of cells or nuclei that are present in a given sample before download, we use the estimated number of cells per sample identified by one of the tested demultiplexing methods.
-However, these estimated demux cell counts simply represent an estimate and we encourage users to investigate the data on their own and make their own decisions on the best demultiplexing method to use for their research purposes. 
+However, these estimated demux cell counts should only be considered a guide; we encourage users to investigate the data on their own and make their own decisions on the best demultiplexing method to use for their research purposes. 
 
-Note that not all cells in a library are included in the estimated demux cell count, as some cells may not be able to be assigned to a particular sample. 
-Estimated demux cell counts will only be reported for multiplexed samples and will not be reported for single-cell or single-nuclei samples that are not multiplexed. 
+Note that not all cells in a library are included in the estimated demux cell count, as some cells may not have been assigned to a sample. 
+Estimated demux cell counts are only reported for multiplexed samples and are not reported for single-cell or single-nuclei samples that are not multiplexed. 
 For more about demultiplexing, see the section on {ref}`processing multiplexed libraries <processing_information:multiplexed libraries>`.
 
 ## What genes are included in the reference transcriptome?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,6 +53,28 @@ However, for most participants, only a single sample was collected and submitted
 Because of this, many of the samples do not have a separate participant ID.
 Participant IDs are only present for samples that were derived from the same participant as at least one other sample.
 
+## What is a multiplexed sample? 
+
+Multiplexed samples refer to samples that have been combined together into one library using cell hashing and then sequenced together. 
+This means that a single library contains cells that correspond to multiple samples. 
+Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library. 
+The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.  
+
+## What are estimated demux cell counts? 
+
+Estimated demux cell counts are provided for multiplexed libraries and refer to the estimated cell counts for each sample that is present in the library. 
+Cells that are included in the estimated cell count are cells that can be confidently assigned to a given sample using a given demultiplexing method. 
+Note that not all cells in a library are included in the estimated demux cell count, as some cells may not be able to be assigned to a particular sample. 
+For more about demultiplexing, see the section on {ref}`processing multiplexed libraries <processing_information:multiplexed libraries>`.
+
+## Why do multiplexed samples have estimated demux cell counts? 
+
+Estimated demux cell counts will only be reported for multiplexed samples and will not be reported for single-cell or single-nuclei samples that are not multiplexed. 
+This is because multiplexed samples have multiple samples combined into one library using cell hashing, and samples have not been separated or demultiplexed. 
+Because there are multiple accepted methods that can be used for demultiplexing, we provide the single multiplexed library with the sample calls from each method, rather than separating out each sample. 
+The {ref}`demultiplexing results <sce_file_contents:demultiplexing results>` can be found in the `SingleCellExperiment` objects for each multiplexed library. 
+The estimated demux cell counts simply represent an estimate of the number of cells per sample based on a single multiplexing method. 
+
 ## What genes are included in the reference transcriptome?
 
 The {ref}`reference transcriptome index <processing_information:reference transcriptome index>` that was used for alignment was constructed by extracting both spliced cDNA and intronic regions from the primary genome assembly GRCh38, Ensembl database version 104 ([see the code used to generate the reference transcriptome](https://github.com/AlexsLemonade/scpca-nf/blob/main/bin/make_splici_fasta.R)).


### PR DESCRIPTION
Closes #77, #73, and #76. 
Stacked on #70. 

I'm adding the three FAQs for multiplexed samples here, what is a multiplexed sample, what are est. demux cell counts, and why do multiplexed samples have est. demux cell counts. I decided to pull this together into one PR, because I thought it would make sense for reviewers to look at all of these together as they are all somewhat linked, especially the ones about estimated demux cell counts. 

I also stacked this on #70 so that I could link to some of the information in the processing and sce file contents docs in answering the questions. 

The one main question I have is if we want to explicitly say that we are reporting the cell counts using genetic demultiplexing? Right now as things are that's what we are using, but I know there was a concern that in the future that wouldn't always be the case. But it feels like something we probably want to include? 

Additionally, is there anymore detail or information that I'm missing that should be included in these explanations? 

As discussed in sprint planning I will request @jashapiro for a first round of review and then request a second reviewer who is less familiar to get their input. 