### PR TITLE
Getting started section for multiplexed samples

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,6 +59,7 @@ Multiplexed samples refer to samples that have been combined together into one l
 This means that a single library contains cells that correspond to multiple samples. 
 Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library. 
 The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.  
+For more information on working with multiplexed samples, see the {ref}`special considerations for multiplexed samples section in getting started with an ScPCA dataset <getting_started:Special considerations for multiplexed samples>`. 
 
 ## What are estimated demux cell counts? 
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -175,7 +175,8 @@ Demultiplexing can then be used to identify the sample that each cell is from.
 Demultiplexing has already been performed using both [`Seurat::HTODemux`](https://satijalab.org/seurat/reference/htodemux) and [`DropletUtils::hashedDrops`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html). 
 For samples where corresponding bulk RNA-sequencing data is available, {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` was also conducted. 
 The results from demultiplexing using these methods have been summarized and are present in the `colData` of the `SingleCellExperiment` object in the `_filtered.rds` file only. 
-The `hashedDrops_sampleid`, `HTODemux_sampleid`, and `vireo_sampleid` columns in the `colData` will identify which sample each cell belongs to in a given library, or if a confident call cannot be identified, will report `NA` for the specified demultiplexing method. 
+The `hashedDrops_sampleid`, `HTODemux_sampleid`, and `vireo_sampleid` columns in the `colData` report the sample called for each cell by the specified demultiplexing method.
+If a confident call was not made for a cell by the demultiplexing method, the column will have a value of `NA`. 
 For more information on how to access the full demultiplexing results, see {ref}`this description of demultiplexing results <sce_file_contents:demultiplexing results>`.
 
 If desired, the sample calls identified from demultiplexing can be used to separate the `SingleCellExperiment` object by sample for downstream analysis. 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -164,9 +164,9 @@ Here are some resources that can be used to get you started working with `AnnDat
 
 ## Special considerations for multiplexed samples 
 
-If the dataset that you have downloaded contains samples that were multiplexed (i.e. cells from mutliple samples have been combined together into one library), then the steps to take after downloading will be a little different than for libraries that only contain cells corresponding to one sample. 
+If the dataset that you have downloaded contains samples that were multiplexed (i.e. cells from mutliple samples have been combined together into one library), then the steps to take after downloading will be a little different than for libraries that only contain cells corresponding to a single sample. 
 Here, multiplexed samples refer to samples that have been combined together into one library using cell hashing and then sequenced together. 
-This means that a single library contains cells that correspond to multiple samples. 
+This means that a single library contains cells or nuclei that correspond to multiple samples. 
 Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library. 
 The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.  
 
@@ -176,17 +176,17 @@ Demultiplexing has already been performed using both [`Seurat::HTODemux`](https:
 For samples where corresponding bulk RNA-sequencing data is available, {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` was also conducted. 
 The results from demultiplexing using these methods have been summarized and are present in the `colData` of the `SingleCellExperiment` object in the `_filtered.rds` file only. 
 The summary of the results will identify which sample each cell belongs to in a given library, or if a confident call cannot be identified, will report `NA`. 
-For more information on how to access the demultiplexing results, see {ref}`this description of demultiplexing results <sce_file_contents:demultiplexing results>`.
+For more information on how to access the full demultiplexing results, see {ref}`this description of demultiplexing results <sce_file_contents:demultiplexing results>`.
 
 If desired, the sample calls identified from demultiplexing can be used to separate the `SingleCellExperiment` object by sample for downstream analysis. 
 
 ```r
 # view the summary of the sample calls for genetic demultiplexing
 # genetic demultiplexing results are stored in the vireo_sampleid column found in the colData
-table(multiplexed_sce$vireo)
+table(multiplexed_sce$vireo_sampleid)
 
-# identify cells that are assigned to sample A
-sampleA_cells <- multiplexed_sce$vireo == "sampleA"
+# identify cells that are assigned to sample A (use `which` to remove NA)
+sampleA_cells <- which(multiplexed_sce$vireo_sampleid == "sampleA")
 
 # create a new sce that only contains cells from sample A
 sampleA_sce <- multiplexed_sce[, sampleA_cells]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -175,7 +175,7 @@ Demultiplexing can then be used to identify the sample that each cell is from.
 Demultiplexing has already been performed using both [`Seurat::HTODemux`](https://satijalab.org/seurat/reference/htodemux) and [`DropletUtils::hashedDrops`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html). 
 For samples where corresponding bulk RNA-sequencing data is available, {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` was also conducted. 
 The results from demultiplexing using these methods have been summarized and are present in the `colData` of the `SingleCellExperiment` object in the `_filtered.rds` file only. 
-The summary of the results will identify which sample each cell belongs to in a given library, or if a confident call cannot be identified, will report `NA`. 
+The `hashedDrops_sampleid`, `HTODemux_sampleid`, and `vireo_sampleid` columns in the `colData` will identify which sample each cell belongs to in a given library, or if a confident call cannot be identified, will report `NA` for the specified demultiplexing method. 
 For more information on how to access the full demultiplexing results, see {ref}`this description of demultiplexing results <sce_file_contents:demultiplexing results>`.
 
 If desired, the sample calls identified from demultiplexing can be used to separate the `SingleCellExperiment` object by sample for downstream analysis. 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -161,3 +161,38 @@ Here are some resources that can be used to get you started working with `AnnDat
 - [Preprocessing and clustering tutorial in scanpy](https://scanpy-tutorials.readthedocs.io/en/latest/pbmc3k.html)
 - [Converting directly from R to Python](https://theislab.github.io/scanpy-in-R/#converting-from-r-to-python)
 - [Homepage for scanpy tutorials](https://scanpy.readthedocs.io/en/latest/tutorials.html)
+
+## Special considerations for multiplexed samples 
+
+If the dataset that you have downloaded contains samples that were multiplexed (i.e. cells from mutliple samples have been combined together into one library), then the steps to take after downloading will be a little different than for libraries that only contain cells corresponding to one sample. 
+Here, multiplexed samples refer to samples that have been combined together into one library using cell hashing and then sequenced together. 
+This means that a single library contains cells that correspond to multiple samples. 
+Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library. 
+The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.  
+
+Libraries containing multiplexed samples can be initially processed using the same workflow described above including removal of [low quality cells](#quality-control), [normalization](#normalization), and [dimensionality reduction](#dimensionality-reduction). 
+Demultiplexing can then be used to identify the sample that each cell is from. 
+Demultiplexing has already been performed using both [`Seurat::HTODemux`](https://satijalab.org/seurat/reference/htodemux) and [`DropletUtils::hashedDrops`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html). 
+For samples where corresponding bulk RNA-sequencing data is available, {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` was also conducted. 
+The results from demultiplexing using these methods have been summarized and are present in the `colData` of the `SingleCellExperiment` object in the `_filtered.rds` file only. 
+The summary of the results will identify which sample each cell belongs to in a given library, or if a confident call cannot be identified, will report `NA`. 
+For more information on how to access the demultiplexing results, see {ref}`this description of demultiplexing results <sce_file_contents:demultiplexing results>`.
+
+If desired, the sample calls identified from demultiplexing can be used to separate the `SingleCellExperiment` object by sample for downstream analysis. 
+
+```r
+# view the summary of the sample calls for genetic demultiplexing
+# genetic demultiplexing results are stored in the vireo_sampleid column found in the colData
+table(multiplexed_sce$vireo)
+
+# identify cells that are assigned to sample A
+sampleA_cells <- multiplexed_sce$vireo == "sampleA"
+
+# create a new sce that only contains cells from sample A
+sampleA_sce <- multiplexed_sce[, sampleA_cells]
+``` 
+
+Here are some additional resources that can be used for working with multiplexed samples (or those with cell hashing): 
+- [Demultiplexing on HTO Abundance, Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.14/OSCA.advanced/droplet-processing.html#demultiplexing-on-hto-abundance)
+- [Seurat vignette on demultiplexing with Seurat::HTODemux](https://satijalab.org/seurat/articles/hashing_vignette.html)
+- [Weber _et al._ (2021) Genetic demultiplexing of pooled single-cell RNA-sequencing samples in cancer facilitates effective experimental design](https://doi.org/10.1093/gigascience/giab062)


### PR DESCRIPTION
Closes #74. 
⚠️ Stacked on #83 ⚠️ 

Here I added a section to the `Getting started with an ScPCA dataset` that includes special considerations for multiplexed samples. I was unsure about the level of detail that we wanted, but based on the two points described in #74, I was sure to include a description of what a multiplex sample is and information on how to filter to the sample of interest. 

I also included a statement about how the initial analysis that is described in the beginning of the getting started section for single sample libraries - filtering, normalization, dimensionality reduction - can be performed as usual. Then I included some details about demultiplexing and identifying which cells belong to which samples, explaining that those results are already summarized and providing a link to the SCE file contents page. I then have a chunk of code showing an example of separating by sample into a new object for downstream analysis. Is there anything from this that is missing or not detailed enough? 

The last little bit I included was a few external resources for people to use based on the types of demultiplexing that we include. In this PR I'm also adding in the link to this section in the FAQ: What is a multiplexed sample. 

Again, I wasn't 100 percent sure on detail and structure here so if there was something else that others had in mind, I am definitely open to it. 