### PR TITLE
Add link to downstream analyses repo 

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,6 +2,9 @@
 
 This section provides information on next steps you might take after downloading a dataset from the ScPCA portal.
 
+More resources for processing single-cell datasets can be found on our Github in the [`scpca-downstream-analyses` repository](https://github.com/AlexsLemonade/scpca-downstream-analyses).
+This repository houses a workflow that can be used to perform initial filtering, dimensionality reduction, normalization, and clustering on single-cell and single-nuclei samples in parallel.
+
 ## Importing ScPCA data into R
 
 Quantified single-cell or single-nuclei gene expression data is provided as an RDS file as described in the {ref}`single cell gene expression file contents section<sce_file_contents:single-cell gene expression file contents>`.
@@ -164,22 +167,22 @@ Here are some resources that can be used to get you started working with `AnnDat
 
 ## Special considerations for multiplexed samples
 
-If the dataset that you have downloaded contains samples that were multiplexed (i.e. cells from multiple samples have been combined together into one library), then the steps to take after downloading will be a little different than for libraries that only contain cells corresponding to a single sample. 
-Here, multiplexed samples refer to samples that have been combined together into one library using cell hashing and then sequenced together. 
-This means that a single library contains cells or nuclei that correspond to multiple samples. 
-Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library. 
-The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.  
+If the dataset that you have downloaded contains samples that were multiplexed (i.e. cells from multiple samples have been combined together into one library), then the steps to take after downloading will be a little different than for libraries that only contain cells corresponding to a single sample.
+Here, multiplexed samples refer to samples that have been combined together into one library using cell hashing and then sequenced together.
+This means that a single library contains cells or nuclei that correspond to multiple samples.
+Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library.
+The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.
 
 Libraries containing multiplexed samples can be initially processed using the same workflow described above including removal of [low quality cells](#quality-control), [normalization](#normalization), and [dimensionality reduction](#dimensionality-reduction).
-Demultiplexing can then be used to identify the sample that each cell is from. 
-Demultiplexing has already been performed using both [`Seurat::HTODemux`](https://satijalab.org/seurat/reference/htodemux) and [`DropletUtils::hashedDrops`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html). 
-For samples where corresponding bulk RNA-sequencing data is available, {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` was also conducted. 
-The results from demultiplexing using these methods have been summarized and are present in the `colData` of the `SingleCellExperiment` object in the `_filtered.rds` file only. 
+Demultiplexing can then be used to identify the sample that each cell is from.
+Demultiplexing has already been performed using both [`Seurat::HTODemux`](https://satijalab.org/seurat/reference/htodemux) and [`DropletUtils::hashedDrops`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html).
+For samples where corresponding bulk RNA-sequencing data is available, {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` was also conducted.
+The results from demultiplexing using these methods have been summarized and are present in the `colData` of the `SingleCellExperiment` object in the `_filtered.rds` file only.
 The `hashedDrops_sampleid`, `HTODemux_sampleid`, and `vireo_sampleid` columns in the `colData` report the sample called for each cell by the specified demultiplexing method.
-If a confident call was not made for a cell by the demultiplexing method, the column will have a value of `NA`. 
+If a confident call was not made for a cell by the demultiplexing method, the column will have a value of `NA`.
 For more information on how to access the full demultiplexing results, see {ref}`this description of demultiplexing results <sce_file_contents:demultiplexing results>`.
 
-If desired, the sample calls identified from demultiplexing can be used to separate the `SingleCellExperiment` object by sample for downstream analysis. 
+If desired, the sample calls identified from demultiplexing can be used to separate the `SingleCellExperiment` object by sample for downstream analysis.
 
 ```r
 # view the summary of the sample calls for genetic demultiplexing
@@ -191,9 +194,9 @@ sampleA_cells <- which(multiplexed_sce$vireo_sampleid == "sampleA")
 
 # create a new sce that only contains cells from sample A
 sampleA_sce <- multiplexed_sce[, sampleA_cells]
-``` 
+```
 
-Here are some additional resources that can be used for working with multiplexed samples (or those with cell hashing): 
+Here are some additional resources that can be used for working with multiplexed samples (or those with cell hashing):
 - [Demultiplexing on HTO Abundance, Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.14/OSCA.advanced/droplet-processing.html#demultiplexing-on-hto-abundance)
 - [Seurat vignette on demultiplexing with Seurat::HTODemux](https://satijalab.org/seurat/articles/hashing_vignette.html)
 - [Weber _et al._ (2021) Genetic demultiplexing of pooled single-cell RNA-sequencing samples in cancer facilitates effective experimental design](https://doi.org/10.1093/gigascience/giab062)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,8 +2,8 @@
 
 This section provides information on next steps you might take after downloading a dataset from the ScPCA portal.
 
-More resources for processing single-cell datasets can be found on our Github in the [`scpca-downstream-analyses` repository](https://github.com/AlexsLemonade/scpca-downstream-analyses).
-This repository houses a workflow that can be used to perform initial filtering, dimensionality reduction, normalization, and clustering on single-cell and single-nuclei samples in parallel.
+We have also provided a workflow that can be used to perform initial filtering, dimensionality reduction, normalization, and clustering on single-cell and single-nuclei samples in parallel.
+This workflow and more resources for processing single-cell datasets can be found on our Github in the [`scpca-downstream-analyses` repository](https://github.com/AlexsLemonade/scpca-downstream-analyses).
 
 ## Importing ScPCA data into R
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,7 +3,7 @@
 This section provides information on next steps you might take after downloading a dataset from the ScPCA portal.
 
 We have also provided a workflow that can be used to perform initial filtering, dimensionality reduction, normalization, and clustering on single-cell and single-nuclei samples in parallel.
-This workflow and more resources for processing single-cell datasets can be found on our Github in the [`scpca-downstream-analyses` repository](https://github.com/AlexsLemonade/scpca-downstream-analyses).
+This workflow and more resources for processing single-cell and single-nuclei datasets can be found on our Github in the [`scpca-downstream-analyses` repository](https://github.com/AlexsLemonade/scpca-downstream-analyses).
 
 ## Importing ScPCA data into R
 


### PR DESCRIPTION
Closes #88 

Here I added a link to the downstream analyses repo in the getting started section. I wasn't quite sure how much detail we wanted to put here, but I wanted to emphasize that there is a workflow that processes samples in parallel and performs the steps mentioned in the getting started doc. I think this is probably the only place in the docs where it makes sense to include a link. 

Also there's some trimming of white space, so apologies for the extra lines in the diff.