### PR TITLE
Include section on post processing of gene expression data in processing information part of docs

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -5,7 +5,9 @@ name: Spell check Markdown files
 # Pull requests to master only.
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - development
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -18,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
-          
+
       - name: Install packages
         run: Rscript --vanilla -e "install.packages('spelling', repos = c(CRAN = 'https://cloud.r-project.org'))"
 

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -22,6 +22,7 @@ demultiplexing
 demux
 Dobin
 DropletUtils
+embeddings
 Ensembl
 et
 fastp
@@ -38,9 +39,12 @@ HTO
 HTODemux
 HTOs
 Hippen
+HVG
+HVGs
 intronic
 introns
 Kaminow
+Marioni
 Pearson
 pre
 pseudogenes

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -21,7 +21,7 @@ We mapped reads to the transcriptome index using `salmon` with the default "sele
 Briefly, selective alignment uses a mapping score validated approach to identify maximal exact matches between reads and the provided index.
 For all samples, we used selective alignment to the `splici` index.
 
-A more detailed description of the mapping strategy invoked by `salmon` in conjunction with `alevin-fry` can be found in [Srivastava _et al._ (2020)](https://doi.org/10.1186/s13059-020-02151-8).
+A more detailed description of the mapping strategy invoked by `salmon` in conjunction with `alevin-fry` can be found in [Srivastava _et al._ 2020](https://doi.org/10.1186/s13059-020-02151-8).
 
 #### Alevin-fry parameters
 
@@ -55,6 +55,21 @@ Only cells that pass this FDR threshold are included in the filtered counts matr
 
 For some libraries, `DropletUtils::emptyDropsCellRanger()` may fail due to low numbers of droplets with reads or other violations of its assumptions.
 For these libraries, only droplets containing at least 100 UMI are included in the filtered counts matrix.
+
+### Processed gene expression data
+
+In addition to the raw gene expression data, we also provide a `_processed.rds` file contianing a `SingleCellExperiment` object with the filtered, normalized counts matrix and embeddings from dimensionality reduction.
+
+Prior to normalization, low-quality cells are removed from the gene by cell counts matrix.
+To predict low-quality cells, we use [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected.
+Cells with a high likelihood of being compromised, greater than 0.75, and cells that do not pass a minimum number of unique genes detected threshold of 200 are removed from the counts matrix present in the `_processed.rds` file.
+
+Log-normalized counts are calculated using the deconvolution method presented in [Lun, Bach, and Marioni 2016](https://doi.org/10.1186/s13059-016-0947-7).
+The log-normalized counts are used to model variance of each gene prior to selecting the top 2000 highly variable genes(HVG).
+The HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
+Finally, the principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
+
+#### Normalization and dimensionality reduction
 
 ## CITE-seq quantification
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -58,7 +58,7 @@ For these libraries, only droplets containing at least 100 UMI are included in t
 
 ### Processed gene expression data
 
-In addition to the raw gene expression data, we also provide a `_processed.rds` file contianing a `SingleCellExperiment` object with the filtered, normalized counts matrix and embeddings from dimensionality reduction.
+In addition to the raw gene expression data, we also provide a `_processed.rds` file containing a `SingleCellExperiment` object with the filtered, normalized counts matrix and embeddings from dimensionality reduction.
 
 Prior to normalization, low-quality cells are removed from the gene by cell counts matrix.
 To predict low-quality cells, we use [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -21,7 +21,7 @@ We mapped reads to the transcriptome index using `salmon` with the default "sele
 Briefly, selective alignment uses a mapping score validated approach to identify maximal exact matches between reads and the provided index.
 For all samples, we used selective alignment to the `splici` index.
 
-A more detailed description of the mapping strategy invoked by `salmon` in conjunction with `alevin-fry` can be found in [Srivastava _et al._ 2020](https://doi.org/10.1186/s13059-020-02151-8).
+A more detailed description of the mapping strategy invoked by `salmon` in conjunction with `alevin-fry` can be found in [Srivastava _et al._ (2020)](https://doi.org/10.1186/s13059-020-02151-8).
 
 #### Alevin-fry parameters
 
@@ -64,7 +64,7 @@ Prior to normalization, low-quality cells are removed from the gene by cell coun
 To identify low-quality cells, we use [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected.
 Cells with a high likelihood of being compromised (greater than 0.75) and cells that do not pass a minimum number of unique genes detected threshold of 200 are removed from the counts matrix present in the `_processed.rds` file.
 
-Log-normalized counts are calculated using the deconvolution method presented in [Lun, Bach, and Marioni 2016](https://doi.org/10.1186/s13059-016-0947-7).
+Log-normalized counts are calculated using the deconvolution method presented in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7).
 The log-normalized counts are used to model variance of each gene prior to selecting the top 2000 highly variable genes (HVGs).
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -58,16 +58,16 @@ For these libraries, only droplets containing at least 100 UMI are included in t
 
 ### Processed gene expression data
 
-In addition to the raw gene expression data, we also provide a `_processed.rds` file containing a `SingleCellExperiment` object with the filtered, normalized counts matrix and embeddings from dimensionality reduction.
+In addition to the raw gene expression data, we also provide a `_processed.rds` file containing a `SingleCellExperiment` object with further filtering applied, a normalized counts matrix, and results from dimensionality reduction.
 
 Prior to normalization, low-quality cells are removed from the gene by cell counts matrix.
-To predict low-quality cells, we use [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected.
-Cells with a high likelihood of being compromised, greater than 0.75, and cells that do not pass a minimum number of unique genes detected threshold of 200 are removed from the counts matrix present in the `_processed.rds` file.
+To identify low-quality cells, we use [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected.
+Cells with a high likelihood of being compromised (greater than 0.75) and cells that do not pass a minimum number of unique genes detected threshold of 200 are removed from the counts matrix present in the `_processed.rds` file.
 
 Log-normalized counts are calculated using the deconvolution method presented in [Lun, Bach, and Marioni 2016](https://doi.org/10.1186/s13059-016-0947-7).
-The log-normalized counts are used to model variance of each gene prior to selecting the top 2000 highly variable genes(HVG).
-The HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
-Finally, the principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
+The log-normalized counts are used to model variance of each gene prior to selecting the top 2000 highly variable genes (HVGs).
+These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
+Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
 ## CITE-seq quantification
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -69,8 +69,6 @@ The log-normalized counts are used to model variance of each gene prior to selec
 The HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, the principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
-#### Normalization and dimensionality reduction
-
 ## CITE-seq quantification
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.


### PR DESCRIPTION
Closes #90 and #96 

This PR starts the documentation of post processing of gene expression data to now include filtered, normalized data and PCA/UMAP embeddings. I started by adding a section to the `processing_information.md` section of the docs that comes after the post alevin-fry section but before the CITE-seq section. I kept things relatively simple by just describing what was done, what thresholds were used, etc. Let me know if I should include more detail here. 

I also created a `development` branch before doing this and filed this PR to that branch so that all changes related to upcoming releases on ScPCA that are not yet available go to `development` first. 

One thing I noticed while doing this is that we have some discrepancies between how we tell people to remove low quality cells in our docs vs. how we are now doing it in the post processing script. We include a `miQC_pass` column in the `_filtered.rds` file that is based on the prob compromised and mito content and we tell people to filter based on that in the getting started section. However, we filter on unique genes to get `_processed.rds`. I just wanted to bring this up because we probably need to address this both in the docs and in `scpca-nf` and I was curious if others have opinions. I think we want to make the `miQC_pass` column consistent with how we are actually filtering. 