### PR TITLE
Document changes to participant ID requirements

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -71,7 +71,7 @@ The `single_cell_metadata.tsv` file is a tab-separated table with one row per li
 | `technology`      | 10X kit used to process library                                |
 | `filtered_cell_count` | Number of cells after filtering with `emptyDrops`          |
 | `submitter_id`    | Original sample identifier from submitter                      |
-| `participant_id`  | Original participant id, if there are multiple samples from the same participant                                                                        |
+| `participant_id`  | Original participant id, required to be present if there are multiple samples from the same participant, optional for all other samples                                                                        |
 | `submitter`       | Submitter name/id                                              |
 | `age`             | Age at time sample was obtained                                |
 | `sex`             | Sex of patient that the sample was obtained from               |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,7 +50,7 @@ The `participant_id`, when present, indicates the participant from which a colle
 For example, one participant may have a sample collected both at initial diagnosis and at relapse.
 This would result in two different sample ID's, but the same participant ID.
 However, for most participants, only a single sample was collected and submitted for sequencing.
-Because of this, many samples do not have a separate participant ID.
+Because of this, many of the samples do not have a separate participant ID.
 A `participant_id` is required for all samples that were derived from the same participant as at least one other sample.
 They may also be present for samples in which there is only one sample collected from a participant, but for this scenario the presence of a `participant_id` is optional.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,8 +50,9 @@ The `participant_id`, when present, indicates the participant from which a colle
 For example, one participant may have a sample collected both at initial diagnosis and at relapse.
 This would result in two different sample ID's, but the same participant ID.
 However, for most participants, only a single sample was collected and submitted for sequencing.
-Because of this, many of the samples do not have a separate participant ID.
-Participant IDs are only present for samples that were derived from the same participant as at least one other sample.
+Because of this, many samples do not have a separate participant ID.
+A `participant_id` is required for all samples that were derived from the same participant as at least one other sample.
+They may also be present for samples in which there is only one sample collected from a participant, but for this scenario the presence of a `participant_id` is optional.
 
 ## What is a multiplexed sample?
 


### PR DESCRIPTION
Closes #107 

I updated the metadata table in the download files section to mention that the participant ID is required for all participants that have multiple samples, but optional in other cases. I also updated the FAQ to reflect when the ID is required vs. optional. 