### PR TITLE
Add CITE post-processing to docs

### DIFF
--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -64,10 +64,24 @@ Prior to normalization, low-quality cells are removed from the gene by cell coun
 To identify low-quality cells, we use [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected.
 Cells with a high likelihood of being compromised (greater than 0.75) and cells that do not pass a minimum number of unique genes detected threshold of 200 are removed from the counts matrix present in the `_processed.rds` file.
 
+If CITE-seq data is present, additional low-quality cells are further removed based on antibody-derived tag (ADT) content, as described in [Processed CITE-seq data](#processed-cite-seq-data).
+
 Log-normalized counts are calculated using the deconvolution method presented in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7).
 The log-normalized counts are used to model variance of each gene prior to selecting the top 2000 highly variable genes (HVGs).
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
+
+### Processed CITE-seq data
+
+If the experiment contains CITE-seq data, further filtering steps are applied to the `SingleCellExperiment` object found in `_processed.rds`.
+An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
+This ambient profile is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
+If negative control ADTs are present, this information is also provided to `DropletUtils::cleanTagCounts()`.
+`DropletUtils::cleanTagCounts()` identifies cells that should be discarded as those with overly high levels of ambient contamination and/or total negative control counts.
+When cells were filtered based on ADT content, the RNA count matrix was also filtered to match such that the same cells are present in both experiments.
+
+Log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
+Importantly, this process may fail if any calculated median size factors have a value of 0, in which case log-normalized ADT counts are not provided in the `_processed.rds` object.
 
 ## CITE-seq quantification
 
@@ -76,7 +90,7 @@ CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quanti
 Reference indices were constructed from the submitter-provided list of antibody barcode sequences corresponding to each library using the `--features` flag of `salmon index`.
 Mapping to these indices followed the same procedures as for RNA-seq data, including mapping with [selective alignment](#selective-alignment) and subsequent [quantification via alevin-fry](#alevin-fry-parameters).
 
-### Combining CITE counts with RNA counts
+### Combining ADT counts with RNA counts
 
 The unfiltered CITE-seq and RNA-seq count matrices often include somewhat different sets of cell barcodes, due to stochastic variation in library construction and sequencing.
 When normalizing these two count matrices to the same set of cells, we chose to prioritize RNA-seq results for broad comparability among libraries with and without CITE-seq data.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -1,33 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
-
-- [Processing information](#processing-information)
-  - [Single-cell and single-nuclei RNA-seq](#single-cell-and-single-nuclei-rna-seq)
-    - [Mapping and quantification using alevin-fry](#mapping-and-quantification-using-alevin-fry)
-      - [Reference transcriptome index](#reference-transcriptome-index)
-      - [Selective alignment](#selective-alignment)
-      - [Alevin-fry parameters](#alevin-fry-parameters)
-    - [Post alevin-fry processing](#post-alevin-fry-processing)
-      - [Combining counts from spliced cDNA and intronic regions](#combining-counts-from-spliced-cdna-and-intronic-regions)
-      - [Filtering cells](#filtering-cells)
-    - [Processed gene expression data](#processed-gene-expression-data)
-  - [CITE-seq quantification](#cite-seq-quantification)
-    - [Combining ADT counts with RNA counts](#combining-adt-counts-with-rna-counts)
-    - [Processed CITE-seq data](#processed-cite-seq-data)
-  - [Multiplexed libraries](#multiplexed-libraries)
-    - [Hashtag oligonucleotide (HTO) quantification](#hashtag-oligonucleotide-hto-quantification)
-    - [HTO demultiplexing](#hto-demultiplexing)
-    - [Genetic demultiplexing](#genetic-demultiplexing)
-  - [Spatial transcriptomics](#spatial-transcriptomics)
-    - [Mapping and quantification using Space Ranger](#mapping-and-quantification-using-space-ranger)
-  - [Bulk RNA samples](#bulk-rna-samples)
-    - [Preprocessing with fastp](#preprocessing-with-fastp)
-    - [Mapping and quantification using salmon](#mapping-and-quantification-using-salmon)
-      - [Salmon parameters](#salmon-parameters)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Processing information
 
 ## Single-cell and single-nuclei RNA-seq

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+**Table of Contents**
 
 - [Processing information](#processing-information)
   - [Single-cell and single-nuclei RNA-seq](#single-cell-and-single-nuclei-rna-seq)

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -1,3 +1,33 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Processing information](#processing-information)
+  - [Single-cell and single-nuclei RNA-seq](#single-cell-and-single-nuclei-rna-seq)
+    - [Mapping and quantification using alevin-fry](#mapping-and-quantification-using-alevin-fry)
+      - [Reference transcriptome index](#reference-transcriptome-index)
+      - [Selective alignment](#selective-alignment)
+      - [Alevin-fry parameters](#alevin-fry-parameters)
+    - [Post alevin-fry processing](#post-alevin-fry-processing)
+      - [Combining counts from spliced cDNA and intronic regions](#combining-counts-from-spliced-cdna-and-intronic-regions)
+      - [Filtering cells](#filtering-cells)
+    - [Processed gene expression data](#processed-gene-expression-data)
+  - [CITE-seq quantification](#cite-seq-quantification)
+    - [Combining ADT counts with RNA counts](#combining-adt-counts-with-rna-counts)
+    - [Processed CITE-seq data](#processed-cite-seq-data)
+  - [Multiplexed libraries](#multiplexed-libraries)
+    - [Hashtag oligonucleotide (HTO) quantification](#hashtag-oligonucleotide-hto-quantification)
+    - [HTO demultiplexing](#hto-demultiplexing)
+    - [Genetic demultiplexing](#genetic-demultiplexing)
+  - [Spatial transcriptomics](#spatial-transcriptomics)
+    - [Mapping and quantification using Space Ranger](#mapping-and-quantification-using-space-ranger)
+  - [Bulk RNA samples](#bulk-rna-samples)
+    - [Preprocessing with fastp](#preprocessing-with-fastp)
+    - [Mapping and quantification using salmon](#mapping-and-quantification-using-salmon)
+      - [Salmon parameters](#salmon-parameters)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Processing information
 
 ## Single-cell and single-nuclei RNA-seq
@@ -71,16 +101,6 @@ The log-normalized counts are used to model variance of each gene prior to selec
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
-### Processed CITE-seq data
-
-If the experiment contains CITE-seq data, further filtering steps are applied to the `SingleCellExperiment` object found in `_processed.rds`.
-An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
-This ambient profile, along with negative control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative control tags are are removed from the counts matrices present in the `_processed.rds` file.
-
-Log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
-Importantly, this process may fail if any calculated median size factors have a value of 0, in which case log-normalized ADT counts are not provided in the `_processed.rds` object.
-
 ## CITE-seq quantification
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.
@@ -95,6 +115,16 @@ When normalizing these two count matrices to the same set of cells, we chose to 
 Any cell barcodes that appeared only in CITE-seq data were discarded.
 Cell barcodes that were present only in the RNA-seq data (i.e., did _not_ appear in the CITE-seq data) were assigned zero counts for all ADTs.
 When cells were [filtered based on RNA-seq content](#filtering-cells) after quantification, the CITE-seq count matrix was filtered to match.
+
+### Processed CITE-seq data
+
+An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
+This ambient profile, along with negative control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
+Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative control tags are are removed from all counts matrices present in the `_processed.rds` file.
+The RNA count matrix was filtered to match, such that the same cells are present in all RNA and CITE-seq counts matrices.
+
+Log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
+Importantly, this process may fail if any calculated median size factors have a value of 0, in which case log-normalized ADT counts are not provided in the `_processed.rds` object.
 
 ## Multiplexed libraries
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -75,10 +75,8 @@ Finally, these principal components are used to calculate the [UMAP (Uniform Man
 
 If the experiment contains CITE-seq data, further filtering steps are applied to the `SingleCellExperiment` object found in `_processed.rds`.
 An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
-This ambient profile is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-If negative control ADTs are present, this information is also provided to `DropletUtils::cleanTagCounts()`.
-`DropletUtils::cleanTagCounts()` identifies cells that should be discarded as those with overly high levels of ambient contamination and/or total negative control counts.
-When cells were filtered based on ADT content, the RNA count matrix was also filtered to match such that the same cells are present in both experiments.
+This ambient profile, along with negative control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
+Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative control tags are are removed from the counts matrices present in the `_processed.rds` file.
 
 Log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
 Importantly, this process may fail if any calculated median size factors have a value of 0, in which case log-normalized ADT counts are not provided in the `_processed.rds` object.

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -133,8 +133,10 @@ CITE-seq data, when present, is included within the `SingleCellExperiment` as an
 altExp(sce, "CITEseq")
 ```
 
-Within this, the main expression matrix is again found in the `counts` assay, with each column corresponding to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponding to an antibody derived tag (ADT).
+Within this, the main expression matrix is again found in the `counts` assay and the normalized expression matrix is again found in the `logcounts` assay.
+For each assay, each column corresponds to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponds to an antibody derived tag (ADT).
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
+
 
 The following additional per-cell data columns for the CITE-seq data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -100,7 +100,7 @@ expt_metadata <- metadata(sce)
 | `filtering_method`  | The method used for cell filtering. One of `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. Only present for `filtered` objects |
 | `umi_cutoff`        | The minimum UMI count per cell used as a threshold for removing empty droplets. Only present for `filtered` objects where the `filtering_method` is `UMI cutoff` |
 | `prob_compromised_cutoff`        | The minimum cutoff for the probability of a cell being compromised, as calculated by `miQC`. Only present for `filtered` objects |
-| `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`; If CITE-seq data is also present, this will also indicate the ADT filtering method as `cleanTagCounts`, e.g. `miQC;cleanTagCounts`. Only present for `filtered` objects.   |
+| `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`. If CITE-seq data is also present, this will also indicate the ADT filtering method as `cleanTagCounts`, e.g. `miQC;cleanTagCounts`. Only present for `filtered` objects.   |
 | `min_gene_cutoff`        | The minimum cutoff for the number of unique genes detected per cell. Only present for `filtered` objects |
 | `normalization`        | The method used for normalization of raw counts. Either `deconvolution`, described in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7), or  `log-normalization`. Only present for `processed` objects |
 | `highly_variable_genes`        | A list of highly variable genes used for dimensionality reduction, determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects |
@@ -133,7 +133,7 @@ CITE-seq data, when present, is included within the `SingleCellExperiment` as an
 altExp(sce, "CITEseq")
 ```
 
-Within this, the main expression matrix is again found in the `counts` assay and the normalized expression matrix is again found in the `logcounts` assay.
+Within this, the main expression matrix is again found in the `counts` assay and the normalized expression matrix is found in the `logcounts` assay.
 For each assay, each column corresponds to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponds to an antibody derived tag (ADT).
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
@@ -142,21 +142,21 @@ The following additional per-cell data columns for the CITE-seq data can be foun
 
 | Column name                | Contents                                          |
 | -------------------------- | ------------------------------------------------- |
-| `altexps_CITEseq_sum`    | UMI count for CITE-seq ADTs                       |
+| `altexps_CITEseq_sum`      | UMI count for CITE-seq ADTs                       |
 | `altexps_CITEseq_detected` | Number of ADTs detected per cell (ADT count > 0 ) |
 | `altexps_CITEseq_percent`  | Percent of `total` UMI count from ADT reads       |
 
 
-The following columns, representing QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html), can be further be found in the `"CITEseq"`  alternative experiment `colData`, accessed with `colData(altExp(sce, "CITEseq"))`.
+In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `colData` of the `"CITEseq"` alternative experiment, accessed with `colData(altExp(sce, "CITEseq"))`.
 
 | Column name                | Contents                                          |
 | -------------------------- | ------------------------------------------------- |
 | `zero.ambient`   | Indicates whether the cell has zero ambient contamination   |
-| `sum.controls` |  The sum of counts for all control features; Only present if negative control ADTs are present. |
-| `high.controls`  | Indicates whether the cell has unusually high total control counts; Only present if negative control ADTs are present.|
-| `ambient.scale` |  The relative amount of ambient contamination; Only present if negative control ADTs are _not_ present. |
-| `high.ambient`  | Indicates whether the cell has unusually high contamination; Only present if negative control ADTs are _not_ present.|
-| `discard`  | Indicates whether the cell should be discarded based on QC statistics; All retained cells in the `_processed.rds` are `FALSE`. |
+| `sum.controls` |  The sum of counts for all control features. Only present if negative control ADTs are present. |
+| `high.controls`  | Indicates whether the cell has unusually high total control counts. Only present if negative control ADTs are present.|
+| `ambient.scale` |  The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present. |
+| `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative control ADTs are _not_ present.|
+| `discard`  | Indicates whether the cell should be discarded based on QC statistics. All retained cells in the `_processed.rds` are `FALSE`. |
 
 
 Metrics for each of the ADTs assayed can be found as a `DataFrame` stored as `rowData` within the alternative experiment:
@@ -174,7 +174,7 @@ This data frame contains the following columns with statistics for each ADT:
 | `target_type` | Whether each ADT is a `target`, `neg_control`, or `pos_control`. This column will be empty if target information is unknown. |
 
 Finally, additional metadata for the CITE-seq data processing can be found in the metadata slot of the alternative experiment.
-This metadata slot has the same contents as the [parent experiment metadata](#experiment-metadata), along with one additional field `ambient_profile` which holds a list of representing the ambient concentrations of each ADT.
+This metadata slot has the same contents as the [parent experiment metadata](#experiment-metadata), along with one additional field, `ambient_profile`, which holds a list of representing the ambient concentrations of each ADT.
 
 ```r
 citeseq_metadata <- metadata(altExp(sce, "CITEseq"))

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -156,6 +156,8 @@ The following columns, representing QC statistics from [`DropletUtils::cleanTagC
 | `high.controls`  | Indicates whether the cell has unusually high total control counts; Only present if negative control ADTs are present.|
 | `ambient.scale` |  The relative amount of ambient contamination; Only present if negative control ADTs are _not_ present. |
 | `high.ambient`  | Indicates whether the cell has unusually high contamination; Only present if negative control ADTs are _not_ present.|
+| `discard`  | Indicates whether the cell should be discarded based on QC statistics; All retained cells in the `_processed.rds` are `FALSE`. |
+
 
 Metrics for each of the ADTs assayed can be found as a `DataFrame` stored as `rowData` within the alternative experiment:
 
@@ -171,7 +173,8 @@ This data frame contains the following columns with statistics for each ADT:
 | `detected`  | Percent of cells in which the ADT was detected (ADT count > 0 ) |
 | `target_type` | Whether each ADT is a `target`, `neg_control`, or `pos_control`. This column will be empty if target information is unknown. |
 
-Finally, additional metadata for the CITE-seq data processing can be found in the metadata slot of the alternative experiment, with the same contents as the [parent experiment metadata](#experiment-metadata)
+Finally, additional metadata for the CITE-seq data processing can be found in the metadata slot of the alternative experiment.
+This metadata slot has the same contents as the [parent experiment metadata](#experiment-metadata), along with one additional field `ambient_profile` which holds a list of representing the ambient concentrations of each ADT.
 
 ```r
 citeseq_metadata <- metadata(altExp(sce, "CITEseq"))

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -100,7 +100,7 @@ expt_metadata <- metadata(sce)
 | `filtering_method`  | The method used for cell filtering. One of `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. Only present for `filtered` objects |
 | `umi_cutoff`        | The minimum UMI count per cell used as a threshold for removing empty droplets. Only present for `filtered` objects where the `filtering_method` is `UMI cutoff` |
 | `prob_compromised_cutoff`        | The minimum cutoff for the probability of a cell being compromised, as calculated by `miQC`. Only present for `filtered` objects |
-| `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`. Only present for `filtered` objects |
+| `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`; If CITE-seq data is also present, this will also indicate the ADT filtering method as `cleanTagCounts`, e.g. `miQC;cleanTagCounts`. Only present for `filtered` objects.   |
 | `min_gene_cutoff`        | The minimum cutoff for the number of unique genes detected per cell. Only present for `filtered` objects |
 | `normalization`        | The method used for normalization of raw counts. Either `deconvolution`, described in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7), or  `log-normalization`. Only present for `processed` objects |
 | `highly_variable_genes`        | A list of highly variable genes used for dimensionality reduction, determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects |
@@ -134,15 +134,26 @@ altExp(sce, "CITEseq")
 ```
 
 Within this, the main expression matrix is again found in the `counts` assay, with each column corresponding to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponding to an antibody derived tag (ADT).
-Column names are again cell barcode sequences and row names the antibody targets for each ADT.
+Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
 The following additional per-cell data columns for the CITE-seq data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).
 
 | Column name                | Contents                                          |
 | -------------------------- | ------------------------------------------------- |
-| `altexps_CITEseq_sum  `    | UMI count for CITE-seq ADTs                       |
+| `altexps_CITEseq_sum`    | UMI count for CITE-seq ADTs                       |
 | `altexps_CITEseq_detected` | Number of ADTs detected per cell (ADT count > 0 ) |
 | `altexps_CITEseq_percent`  | Percent of `total` UMI count from ADT reads       |
+
+
+The following columns, representing QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html), can be further be found in the `"CITEseq"`  alternative experiment `colData`, accessed with `colData(altExp(sce, "CITEseq"))`.
+
+| Column name                | Contents                                          |
+| -------------------------- | ------------------------------------------------- |
+| `zero.ambient`   | Indicates whether the cell has zero ambient contamination   |
+| `sum.controls` |  The sum of counts for all control features; Only present if negative control ADTs are present. |
+| `high.controls`  | Indicates whether the cell has unusually high total control counts; Only present if negative control ADTs are present.|
+| `ambient.scale` |  The relative amount of ambient contamination; Only present if negative control ADTs are _not_ present. |
+| `high.ambient`  | Indicates whether the cell has unusually high contamination; Only present if negative control ADTs are _not_ present.|
 
 Metrics for each of the ADTs assayed can be found as a `DataFrame` stored as `rowData` within the alternative experiment:
 
@@ -156,6 +167,7 @@ This data frame contains the following columns with statistics for each ADT:
 | ----------- | -------------------------------------------------------------- |
 | `mean`      | Mean ADT count across all cells/droplets                       |
 | `detected`  | Percent of cells in which the ADT was detected (ADT count > 0 ) |
+| `target_type` | Whether each ADT is a `target`, `neg_control`, or `pos_control`. This column will be empty if target information is unknown. |
 
 Finally, additional metadata for the CITE-seq data processing can be found in the metadata slot of the alternative experiment, with the same contents as the [parent experiment metadata](#experiment-metadata)
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -155,7 +155,7 @@ In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`]
 | `high.controls`  | Indicates whether the cell has unusually high total control counts. Only present if negative control ADTs are present.|
 | `ambient.scale` |  The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present. |
 | `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative control ADTs are _not_ present.|
-| `discard`  | Indicates whether the cell should be discarded based on QC statistics. All retained cells in the `_processed.rds` are `FALSE`. |
+| `discard`  | Indicates whether the cell should be discarded based on QC statistics. |
 
 
 Metrics for each of the ADTs assayed can be found as a `DataFrame` stored as `rowData` within the alternative experiment:

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -54,8 +54,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).  |
-| `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200).
-All cells labeled as `Remove` were removed prior to writing the `_processed.rds` file and therefore all cells found in the `_processed.rds` file will be labeled `Keep`. |
+| `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200; if CITE-seq is present, the alternative experiment `discard` column is `TRUE`). All cells labeled as `Remove` were removed prior to writing the `_processed.rds` file, and therefore all cells found in the `_processed.rds` file will be labeled `Keep`. |
 
 ### Gene information and metrics
 


### PR DESCRIPTION
Closes #106 
This PR adds information about CITE-seq processing into the portal docs (along with some misc typo/wording fixes), based on work done in:
- https://github.com/AlexsLemonade/scpca-nf/pull/312 (filtering; merged) 
- https://github.com/AlexsLemonade/scpca-nf/pull/325 (normalization; still under review)

Any feedback about the level of detail I've added or whether I've missed a spot is great here! I'm opening this as a draft only because normalization details may change during review of the code itself, and I'll mark this as formally ready for review once the code is finalized. In the meantime feel free to poke around and leave feedback as needed!