### PR TITLE
Update docs: no ADT filtering & ADT modality

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -43,6 +43,7 @@ HVG
 HVGs
 intronic
 introns
+isotype
 Kaminow
 Marioni
 Pearson

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -68,7 +68,7 @@ The `single_cell_metadata.tsv` file is a tab-separated table with one row per li
 | `scpca_sample_id` | Sample ID in the form `SCPCS000000`                            |
 | `scpca_library_id` | Library ID in the form `SCPCL000000`                          |
 | `seq_unit`        | `cell` for single-cell samples or `nucleus` for single-nucleus samples |
-| `technology`      | 10X kit used to process library                                |
+| `technology`      | 10x kit used to process library                                |
 | `filtered_cell_count` | Number of cells after filtering with `emptyDrops`          |
 | `submitter_id`    | Original sample identifier from submitter                      |
 | `participant_id`  | Original participant id, required when there are multiple samples from the same participant, optional for all other samples                                                                        |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -103,7 +103,7 @@ If desired, these can be converted into Seurat objects.
 
 You will need to [install and load the `Seurat` package](https://satijalab.org/seurat/articles/install.html) to work with Seurat objects.
 
-For libraries that only contain RNA-sequencing data (i.e. do not have an ADT library found in the `altExp` of the `SingleCellExperiment` object), you can use the following commands:
+For libraries that only contain RNA-seq data (i.e., do not have an ADT library found in the `altExp` of the `SingleCellExperiment` object), you can use the following commands:
 
 ```r
 library(Seurat)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -153,7 +153,7 @@ seurat_object[["ADT"]] <- adt_assay
 
 We provide single-cell and single-nuclei gene expression data as RDS files, which must be opened in R to view the contents.
 If you prefer to work in Python, there are a variety of ways of converting the count data to Python-compatible formats.
-We have found that one of the more efficient is conversion via the 10X format using [`DropletUtils::write10xCounts()`](https://rdrr.io/bioc/DropletUtils/man/write10xCounts.html).
+We have found that one of the more efficient is conversion via the 10x format using [`DropletUtils::write10xCounts()`](https://rdrr.io/bioc/DropletUtils/man/write10xCounts.html).
 Note that you will need to install the [`DropletUtils` package](https://www.bioconductor.org/packages/devel/bioc/html/DropletUtils.html) to use this function.
 
 When used as described below, `DropletUtils::write10xCounts()` will output three files to a new directory, following the format used by Cell Ranger 3.0 (and later):
@@ -167,7 +167,7 @@ library(SingleCellExperiment)
 # read in the RDS file to be converted
 sce <- readRDS("SCPCL000000_filtered.rds")
 
-# write counts to 10X format and save to a folder named "SCPCL000000-rna"
+# write counts to 10x format and save to a folder named "SCPCL000000-rna"
 DropletUtils::write10xCounts("SCPCL000000-rna", counts(sce),
                              barcodes = colnames(sce),
                              gene.id = rownames(sce),
@@ -179,7 +179,7 @@ DropletUtils::write10xCounts("SCPCL000000-rna", counts(sce),
 If a library has associated ADT data, you will have to save that separately.
 
 ```r
-# write ADT counts to 10X format
+# write ADT counts to 10x format
 DropletUtils::write10xCounts("SCPCL000000-adt", counts(altExp(sce)),
                              barcodes = colnames(altExp(sce)),
                              gene.id = rownames(altExp(sce)),
@@ -194,7 +194,7 @@ Note that you will need to [install the `scanpy` package](https://scanpy.readthe
 ```python
 import scanpy as sc
 
-#read in 10X formatted files
+#read in 10x formatted files
 rna_file_directory = "SCPCL000000-rna"
 anndata_object = sc.read_10x_mtx(rna_file_directory)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,7 +38,7 @@ scpca_sample <- readRDS("SCPCL000000_filtered.rds")
 A sample ID, labeled as `scpca_sample_id` and indicated by the prefix `SCPCS`, represents a unique tissue that was collected from a participant.
 
 The library ID, labeled as `scpca_library_id` and indicated by the prefix `SCPCL`, represents a single set of cells from a tissue sample, or a particular combination of samples in the case of multiplexed libraries.
-For single-cell or single-nuclei experiments, this will be the result of emulsion and droplet generation using the 10X Genomics workflow, potentially including both RNA-seq, CITE-seq and cell hashing sequencing libraries.
+For single-cell or single-nuclei experiments, this will be the result of emulsion and droplet generation using the 10X Genomics workflow, potentially including both RNA-seq, ADT (i.e. from CITE-seq), and cell hashing sequencing libraries.
 Multiplexed libraries will have more than one sample ID corresponding to each library ID.
 
 In most cases, each sample will only have one corresponding single-cell or single-nuclei library, and may also have an associated bulk RNA-seq library.
@@ -103,7 +103,7 @@ If desired, these can be converted into Seurat objects.
 
 You will need to [install and load the `Seurat` package](https://satijalab.org/seurat/articles/install.html) to work with Seurat objects.
 
-For libraries that only contain RNA-sequencing data (i.e. do not have a CITE-seq library found in the `altExp` of the `SingleCellExperiment` object), you can use the following commands:
+For libraries that only contain RNA-sequencing data (i.e. do not have an ADT library found in the `altExp` of the `SingleCellExperiment` object), you can use the following commands:
 
 ```r
 library(Seurat)
@@ -135,18 +135,18 @@ seurat_object[["RNA"]]@meta.features <- row_metadata
 seurat_object@misc <- metadata(sce)
 ```
 
-For `SingleCellExperiment` objects from libraries with both RNA-seq and CITE-seq data, you can use the following additional commands to add a second assay containing the CITE-seq counts and associated feature data:
+For `SingleCellExperiment` objects from libraries with both RNA-seq and ADT data, you can use the following additional commands to add a second assay containing the ADT counts and associated feature data:
 
 ```r
-# create assay object in Seurat from CITE-seq counts found in altExp(SingleCellExperiment)
-cite_assay <- CreateAssayObject(counts = counts(altExp(sce)))
+# create assay object in Seurat from ADT counts found in altExp(SingleCellExperiment)
+adt_assay <- CreateAssayObject(counts = counts(altExp(sce)))
 
 # optional: add row metadata (rowData) from altExp to assay
-cite_row_metadata <- as.data.frame(rowData(altExp(sce)))
-cite_assay@meta.features <- cite_row_metadata
+adt_row_metadata <- as.data.frame(rowData(altExp(sce)))
+adt_assay@meta.features <- adt_row_metadata
 
 # add altExp from SingleCellExperiment as second assay to Seurat
-seurat_object[["CITE"]] <- cite_assay
+seurat_object[["ADT"]] <- adt_assay
 ```
 
 ## What if I want to use Python instead of R?
@@ -176,11 +176,11 @@ DropletUtils::write10xCounts("SCPCL000000-rna", counts(sce),
 
 ```
 
-If a library has associated CITE-seq that exists, you will have to save that separately.
+If a library has associated ADT data, you will have to save that separately.
 
 ```r
-# write CITE-seq counts to 10X format
-DropletUtils::write10xCounts("SCPCL000000-cite", counts(altExp(sce)),
+# write ADT counts to 10X format
+DropletUtils::write10xCounts("SCPCL000000-adt", counts(altExp(sce)),
                              barcodes = colnames(altExp(sce)),
                              gene.id = rownames(altExp(sce)),
                              gene.type = "Antibody Capture",
@@ -198,11 +198,11 @@ import scanpy as sc
 rna_file_directory = "SCPCL000000-rna"
 anndata_object = sc.read_10x_mtx(rna_file_directory)
 
-cite_file_directory = "SCPCL000000-cite"
-cite_anndata = sc.read_10x_mtx(cite_file_directory)
+adt_file_directory = "SCPCL000000-adt"
+adt_anndata = sc.read_10x_mtx(adt_file_directory)
 
-# append CITE-seq anndata to RNA-seq anndata
-anndata_object['CITE'] = cite_anndata.to_df()
+# append ADT anndata to RNA-seq anndata
+anndata_object["ADT"] = adt_anndata.to_df()
 ```
 
 It should be noted that in this conversion the `colData`, `rowData`, and metadata that are found in the original `SingleCellExperiment` objects will not be retained.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,7 +38,7 @@ scpca_sample <- readRDS("SCPCL000000_filtered.rds")
 A sample ID, labeled as `scpca_sample_id` and indicated by the prefix `SCPCS`, represents a unique tissue that was collected from a participant.
 
 The library ID, labeled as `scpca_library_id` and indicated by the prefix `SCPCL`, represents a single set of cells from a tissue sample, or a particular combination of samples in the case of multiplexed libraries.
-For single-cell or single-nuclei experiments, this will be the result of emulsion and droplet generation using the 10X Genomics workflow, potentially including both RNA-seq, ADT (i.e. from CITE-seq), and cell hashing sequencing libraries.
+For single-cell or single-nuclei experiments, this will be the result of emulsion and droplet generation using the 10x Genomics workflow, potentially including both RNA-seq, ADT (i.e., from CITE-seq), and cell hashing sequencing libraries.
 Multiplexed libraries will have more than one sample ID corresponding to each library ID.
 
 In most cases, each sample will only have one corresponding single-cell or single-nuclei library, and may also have an associated bulk RNA-seq library.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -91,8 +91,8 @@ This ambient profile, along with negative/isotype control information, if presen
 Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative/isotype control tags are indicated for removal within the `_processed.rds` file, but they are not actually removed.
 
 For all cells that _would be_ retained if `DropletUtils::cleanTagCounts()` filtering were applied, log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
-Any cells that would be filtered out as determined by `DropletUtils::cleanTagCounts()`, normalized values are not calculated but are instead assigned `NA` values.
-Importantly, all normalization may fail if any calculated median size factors have a value of 0, in which case log-normalized ADT counts are not provided in the `_processed.rds` object.
+For any cells that would be filtered out as determined by `DropletUtils::cleanTagCounts()`, normalized values are not calculated but are instead assigned `NA` values.
+Importantly, if any calculated median size factors have a value of 0, normalization will fail, and log-normalized ADT counts are not provided in the `_processed.rds` object.
 
 ## Multiplexed libraries
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -87,8 +87,8 @@ When cells were [filtered based on RNA-seq content](#filtering-cells) after quan
 ### Processed CITE-seq data
 
 An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
-This ambient profile, along with negative control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative (isotype) control tags are indicated for removal within the `_processed.rds` file, but they are not actually removed.
+This ambient profile, along with negative/isotype control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
+Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative/isotype control tags are indicated for removal within the `_processed.rds` file, but they are not actually removed.
 
 For all cells that _would be_ retained if `DropletUtils::cleanTagCounts()` filtering were applied, log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
 Any cells that would be filtered out as determined by `DropletUtils::cleanTagCounts()`, normalized values are not calculated but are instead assigned `NA` values.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -87,7 +87,7 @@ When cells were [filtered based on RNA-seq content](#filtering-cells) after quan
 ### Processed ADT data
 
 An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
-This ambient profile, along with negative/isotype control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
+This ambient profile, along with negative/isotype control information, if present, is then used as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
 Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative/isotype control tags are indicated for removal within the `_processed.rds` file, but they are not actually removed.
 
 For all cells that _would be_ retained if `DropletUtils::cleanTagCounts()` filtering were applied, log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -69,7 +69,7 @@ The log-normalized counts are used to model variance of each gene prior to selec
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
-## CITE-seq quantification
+## ADT quantification from CITE-seq experiments
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.
 
@@ -78,13 +78,13 @@ Mapping to these indices followed the same procedures as for RNA-seq data, inclu
 
 ### Combining ADT counts with RNA counts
 
-The unfiltered CITE-seq and RNA-seq count matrices often include somewhat different sets of cell barcodes, due to stochastic variation in library construction and sequencing.
-When normalizing these two count matrices to the same set of cells, we chose to prioritize RNA-seq results for broad comparability among libraries with and without CITE-seq data.
-Any cell barcodes that appeared only in CITE-seq data were discarded.
-Cell barcodes that were present only in the RNA-seq data (i.e., did _not_ appear in the CITE-seq data) were assigned zero counts for all ADTs.
-When cells were [filtered based on RNA-seq content](#filtering-cells) after quantification, the CITE-seq count matrix was filtered to match.
+The unfiltered ADT and RNA-seq count matrices often include somewhat different sets of cell barcodes, due to stochastic variation in library construction and sequencing.
+When normalizing these two count matrices to the same set of cells, we chose to prioritize RNA-seq results for broad comparability among libraries with and without ADT data.
+Any cell barcodes that appeared only in ADT data were discarded.
+Cell barcodes that were present only in the RNA-seq data (i.e., did _not_ appear in the ADT data) were assigned zero counts for all ADTs.
+When cells were [filtered based on RNA-seq content](#filtering-cells) after quantification, the ADT count matrix was filtered to match.
 
-### Processed CITE-seq data
+### Processed ADT data
 
 An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
 This ambient profile, along with negative/isotype control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
@@ -104,7 +104,7 @@ HTO reads were also quantified using  [`salmon alevin`](https://salmon.readthedo
 Reference indices were constructed from the submitter-provided list of HTO sequences corresponding to each library using the `--features` flag of `salmon index`.
 Mapping to these indices followed the same procedures as for RNA-seq data, including mapping with [selective alignment](#selective-alignment) and subsequent [quantification via alevin-fry](#alevin-fry-parameters).
 
-As with the [CITE-seq data](#combining-cite-counts-with-rna-counts), we retained all cells with RNA-seq data, setting HTO counts to zero for any missing cell barcodes.
+As with the [ADT data](#combining-adt-counts-with-rna-counts), we retained all cells with RNA-seq data, setting HTO counts to zero for any missing cell barcodes.
 When cells were [filtered based on RNA-seq content](#filtering-cells) after quantification, the HTO count matrix was filtered to match.
 
 ### HTO demultiplexing

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -81,18 +81,18 @@ Mapping to these indices followed the same procedures as for RNA-seq data, inclu
 The unfiltered ADT and RNA-seq count matrices often include somewhat different sets of cell barcodes, due to stochastic variation in library construction and sequencing.
 When normalizing these two count matrices to the same set of cells, we chose to prioritize RNA-seq results for broad comparability among libraries with and without ADT data.
 Any cell barcodes that appeared only in ADT data were discarded.
-Cell barcodes that were present only in the RNA-seq data (i.e., did _not_ appear in the ADT data) were assigned zero counts for all ADTs.
+Cell barcodes that were present only in the RNA-seq data (i.e., did not appear in the ADT data) were assigned zero counts for all ADTs.
 When cells were [filtered based on RNA-seq content](#filtering-cells) after quantification, the ADT count matrix was filtered to match.
 
 ### Processed ADT data
 
 An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
-This ambient profile, along with negative/isotype control information, if present, is then used as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative/isotype control tags are indicated for removal within the `_processed.rds` file, but they are not actually removed.
+Quality-control statistics were calculated with [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) using this ambient profile, along with negative/isotype control information, if present.
+Low quality cells identified by `DropletUtils::cleanTagCounts()` (those having high levels of ambient contamination or substantial negative/isotype control tags) are flagged within the `_processed.rds` file by the `adt_scpca_filter` `colData` column, but are not removed.
 
-For all cells that _would be_ retained if `DropletUtils::cleanTagCounts()` filtering were applied, log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
-For any cells that would be filtered out as determined by `DropletUtils::cleanTagCounts()`, normalized values are not calculated but are instead assigned `NA` values.
-Importantly, if any calculated median size factors have a value of 0, normalization will fail, and log-normalized ADT counts are not provided in the `_processed.rds` object.
+For all cells that would be retained if `DropletUtils::cleanTagCounts()` filtering were applied, log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
+Normalized counts for cells that would be filtered out by `DropletUtils::cleanTagCounts()` are assigned as `NA`.
+If normalization fails, log-normalized ADT counts are not provided in the `_processed.rds` object.
 
 ## Multiplexed libraries
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -64,8 +64,6 @@ Prior to normalization, low-quality cells are removed from the gene by cell coun
 To identify low-quality cells, we use [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected.
 Cells with a high likelihood of being compromised (greater than 0.75) and cells that do not pass a minimum number of unique genes detected threshold of 200 are removed from the counts matrix present in the `_processed.rds` file.
 
-If CITE-seq data is present, additional low-quality cells are further removed based on antibody-derived tag (ADT) content, as described in [Processed CITE-seq data](#processed-cite-seq-data).
-
 Log-normalized counts are calculated using the deconvolution method presented in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7).
 The log-normalized counts are used to model variance of each gene prior to selecting the top 2000 highly variable genes (HVGs).
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
@@ -90,11 +88,11 @@ When cells were [filtered based on RNA-seq content](#filtering-cells) after quan
 
 An ambient profile representing antibody-derived tag (ADT) proportions present in the ambient solution is calculated from the `_unfiltered.rds` object using [`DropletUtils::ambientProfileEmpty()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/ambientProfileEmpty.html).
 This ambient profile, along with negative control information, if present, is then as input to calculate quality-control statistics using [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative control tags are are removed from all counts matrices present in the `_processed.rds` file.
-The RNA count matrix was filtered to match, such that the same cells are present in all RNA and CITE-seq counts matrices.
+Cells identified by `DropletUtils::cleanTagCounts()` as having high levels of ambient contamination and/or negative (isotype) control tags are indicated for removal within the `_processed.rds` file, but they are not actually removed.
 
-Log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
-Importantly, this process may fail if any calculated median size factors have a value of 0, in which case log-normalized ADT counts are not provided in the `_processed.rds` object.
+For all cells that _would be_ retained if `DropletUtils::cleanTagCounts()` filtering were applied, log-normalized ADT counts are calculated using [median-based normalization](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm), again making use of the baseline ambient profile.
+Any cells that would be filtered out as determined by `DropletUtils::cleanTagCounts()`, normalized values are not calculated but are instead assigned `NA` values.
+Importantly, all normalization may fail if any calculated median size factors have a value of 0, in which case log-normalized ADT counts are not provided in the `_processed.rds` object.
 
 ## Multiplexed libraries
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -28,7 +28,7 @@ A more detailed description of the mapping strategy invoked by `salmon` in conju
 After mapping FASTQ files using selective alignment to the `splici` index, we continued with the `alevin-fry` pipeline using the following parameters:
 
 1. During the [`generate-permit-list` step of `alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/generate_permit_list.html), we used the `--unfiltered-pl` option, which returns any cell with at least 1 read found in a reference barcode list.
-For our reference barcode list, we used a list of all possible cell barcodes from 10X Genomics.
+For our reference barcode list, we used a list of all possible cell barcodes from 10x Genomics.
 
 2. We chose to use the `cr-like-em` resolution strategy for [feature quantification and UMI de-duplication](https://alevin-fry.readthedocs.io/en/latest/quant.html).
 Similar to the way Cell Ranger performs feature quantification, the `cr-like-em` resolution strategy assigns all UMIs that align to a single gene to that gene.
@@ -132,10 +132,10 @@ For information on where the demultiplexing calls can be found, see {ref}`the se
 ### Mapping and quantification using Space Ranger
 
 Processing spatial transcriptomics libraries requires two steps - gene expression quantification and tissue detection.
-In the absence of independent tissue detection methods to use with Alevin-fry, we used [10X Genomics' Space Ranger](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/what-is-space-ranger) to obtain both gene expression and spatial information.
+In the absence of independent tissue detection methods to use with Alevin-fry, we used [10x Genomics' Space Ranger](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/what-is-space-ranger) to obtain both gene expression and spatial information.
 [`spaceranger count`](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/using/count) takes FASTQ files and a microscopic slide image as input and performs alignment, quantification, and tissue detection for each spot.
 In contrast to `alevin-fry`, which maps reads to a [reference transcriptome index](#reference-transcriptome-index), Space Ranger aligns transcript reads to the reference genome using `STAR` ([Dobin _et al._ 2012](https://doi.org/10.1093/bioinformatics/bts635)).
-See the 10X documentation for more information on how Space Ranger [quantifies gene expression](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/algorithms/overview) and [detects tissue](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/algorithms/imaging).
+See the 10x documentation for more information on how Space Ranger [quantifies gene expression](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/algorithms/overview) and [detects tissue](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/algorithms/imaging).
 
 ## Bulk RNA samples
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -135,8 +135,7 @@ altExp(sce, "adt")
 ```
 
 Within this, the main expression matrix is again found in the `counts` assay and the normalized expression matrix is found in the `logcounts` assay.
-!!!!!!!! TODO: not everything is normalized. !!!!!!!!!!!
-
+Note that only cells which are denoted as "Keep" in both the `colData(sce)$scpca_filter` and  `colData(sce)$adt_scpca_filter` column (as described in #cell-metrics) have normalized expression values in `logcounts`, and all other cells are assigned `NA` values.
 For each assay, each column corresponds to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponds to an antibody derived tag (ADT).
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
@@ -155,10 +154,10 @@ In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`]
 | Column name                | Contents                                          |
 | -------------------------- | ------------------------------------------------- |
 | `zero.ambient`   | Indicates whether the cell has zero ambient contamination   |
-| `sum.controls` |  The sum of counts for all control features. Only present if negative control ADTs are present. |
-| `high.controls`  | Indicates whether the cell has unusually high total control counts. Only present if negative control ADTs are present.|
+| `sum.controls` |  The sum of counts for all control features. Only present if negative/isotype control ADTs are present. |
+| `high.controls`  | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present.|
 | `ambient.scale` |  The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present. |
-| `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative control ADTs are _not_ present.|
+| `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present.|
 | `discard`  | Indicates whether the cell should be discarded based on QC statistics. |
 
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -135,10 +135,11 @@ altExp(sce, "adt")
 ```
 
 Within this, the main expression matrix is again found in the `counts` assay and the normalized expression matrix is found in the `logcounts` assay.
-Note that only cells which are denoted as "Keep" in both the `colData(sce)$scpca_filter` and  `colData(sce)$adt_scpca_filter` column (as described in #cell-metrics) have normalized expression values in `logcounts`, and all other cells are assigned `NA` values.
 For each assay, each column corresponds to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponds to an antibody derived tag (ADT).
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
+Note that only cells which are denoted as "Keep" in both the `colData(sce)$scpca_filter` and  `colData(sce)$adt_scpca_filter` column (as described in #cell-metrics) have normalized expression values in the `logcounts` assay, and all other cells are assigned `NA` values.
+However, as described in the {ref}`processed CITE-seq data section <processing_information:Processed CITE-seq data>`, normalization may fail under certain circumstances, in which case there will be no `logcounts` normalized expression matrix present in the alternative experiment.
 
 The following additional per-cell data columns for the ADT data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -174,7 +174,7 @@ This data frame contains the following columns with statistics for each ADT:
 | ----------- | -------------------------------------------------------------- |
 | `mean`      | Mean ADT count across all cells/droplets                       |
 | `detected`  | Percent of cells in which the ADT was detected (ADT count > 0 ) |
-| `target_type` | Whether each ADT is a target (`target`), negative/isotype control (`neg_control`), or positive control (`pos_control`). If this information was not provided, all ADTs will have been considered targets and thusly labeled. |
+| `target_type` | Whether each ADT is a target (`target`), negative/isotype control (`neg_control`), or positive control (`pos_control`). If this information was not provided, all ADTs will have been considered targets and labeled as such. |
 
 Finally, additional metadata for ADT processing can be found in the metadata slot of the alternative experiment.
 This metadata slot has the same contents as the [parent experiment metadata](#experiment-metadata), along with one additional field, `ambient_profile`, which holds a list of representing the ambient concentrations of each ADT.

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -139,7 +139,7 @@ For each assay, each column corresponds to a cell or droplet (in the same order 
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
 Note that only cells which are denoted as "Keep" in both the `colData(sce)$scpca_filter` and  `colData(sce)$adt_scpca_filter` column (as described in #cell-metrics) have normalized expression values in the `logcounts` assay, and all other cells are assigned `NA` values.
-However, as described in the {ref}`processed CITE-seq data section <processing_information:Processed CITE-seq data>`, normalization may fail under certain circumstances, in which case there will be no `logcounts` normalized expression matrix present in the alternative experiment.
+However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances, in which case there will be no `logcounts` normalized expression matrix present in the alternative experiment.
 
 The following additional per-cell data columns for the ADT data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -54,7 +54,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).  |
- `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
+| `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
 | `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
 
 ### Gene information and metrics
@@ -101,7 +101,7 @@ expt_metadata <- metadata(sce)
 | `umi_cutoff`        | The minimum UMI count per cell used as a threshold for removing empty droplets. Only present for `filtered` objects where the `filtering_method` is `UMI cutoff` |
 | `prob_compromised_cutoff`        | The minimum cutoff for the probability of a cell being compromised, as calculated by `miQC`. Only present for `filtered` objects |
 | `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`.  |
-| `adt_scpca_filter_method`        | If CITE-seq was performed, method used by the Data Lab to identify cells to be filtered prior to normalization, based on ADT counts. Either `cleanTagCounts with isotype controls` or `cleanTagCounts without isotype controls`, if controls are present or absent, respectively.  |
+| `adt_scpca_filter_method`        | If CITE-seq was performed, method used by the Data Lab to identify cells to be filtered prior to normalization, based on ADT counts. Either `cleanTagCounts with isotype controls` or `cleanTagCounts without isotype controls`|
 | `min_gene_cutoff`        | The minimum cutoff for the number of unique genes detected per cell. Only present for `filtered` objects |
 | `normalization`        | The method used for normalization of raw RNA counts. Either `deconvolution`, described in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7), or  `log-normalization`. Only present for `processed` objects |
 | `highly_variable_genes`        | A list of highly variable genes used for dimensionality reduction, determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects |
@@ -126,7 +126,7 @@ The following command can be used to access the UMAP results:
 reducedDim(sce,"UMAP")
 ```
 
-## Additional SingleCellExperiment components for ADT (CITE-seq) libraries
+## Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags)
 
 ADT data from CITE-seq experiments, when present, is included within the `SingleCellExperiment` as an "Alternative Experiment" named `"adt"` , which can be accessed with the following command:
 
@@ -138,7 +138,7 @@ Within this, the main expression matrix is again found in the `counts` assay and
 For each assay, each column corresponds to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponds to an antibody derived tag (ADT).
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
-Note that only cells which are denoted as "Keep" in both the `colData(sce)$scpca_filter` and  `colData(sce)$adt_scpca_filter` column (as described in #cell-metrics) have normalized expression values in the `logcounts` assay, and all other cells are assigned `NA` values.
+Note that only cells which are denoted as "Keep" in  the `colData(sce)$adt_scpca_filter` column (as described in #cell-metrics) have normalized expression values in the `logcounts` assay, and all other cells are assigned `NA` values.
 However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances, in which case there will be no `logcounts` normalized expression matrix present in the alternative experiment.
 
 The following additional per-cell data columns for the ADT data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -54,7 +54,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).  |
- `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200 |
+ `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
 | `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
 
 ### Gene information and metrics
@@ -101,7 +101,7 @@ expt_metadata <- metadata(sce)
 | `umi_cutoff`        | The minimum UMI count per cell used as a threshold for removing empty droplets. Only present for `filtered` objects where the `filtering_method` is `UMI cutoff` |
 | `prob_compromised_cutoff`        | The minimum cutoff for the probability of a cell being compromised, as calculated by `miQC`. Only present for `filtered` objects |
 | `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`.  |
-| `adt_scpca_filter_method`        | If CITE-seq was performed, method used by the Data Lab to identify cells to be filtered prior to normalization, based on ADT-level information. Either `cleanTagCounts with isotype controls` or `cleanTagCounts without isotype controls`, if controls are present or absent, respectively.  |
+| `adt_scpca_filter_method`        | If CITE-seq was performed, method used by the Data Lab to identify cells to be filtered prior to normalization, based on ADT counts. Either `cleanTagCounts with isotype controls` or `cleanTagCounts without isotype controls`, if controls are present or absent, respectively.  |
 | `min_gene_cutoff`        | The minimum cutoff for the number of unique genes detected per cell. Only present for `filtered` objects |
 | `normalization`        | The method used for normalization of raw RNA counts. Either `deconvolution`, described in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7), or  `log-normalization`. Only present for `processed` objects |
 | `highly_variable_genes`        | A list of highly variable genes used for dimensionality reduction, determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects |

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -1,7 +1,7 @@
 # Single-cell gene expression file contents
 
 Single-cell or single-nuclei gene expression data (unfiltered, filtered, or processed) is provided for use with R as an RDS file containing a [`SingleCellExperiment` object](http://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html).
-This object contains the expression data, cell and gene metrics, associated metadata, and, in the case of multimodal data like CITE-seq, data from additional cell-based assays.
+This object contains the expression data, cell and gene metrics, associated metadata, and, in the case of multimodal data like ADTs from CITE-seq experiments, data from additional cell-based assays.
 
 We highly encourage you to familiarize yourself with the general object structure and functions available as part of the [`SingleCellExperiment` package](https://bioconductor.org/packages/3.13/bioc/html/SingleCellExperiment.html) from Bioconductor.
 Below we present some details about the specific contents of the objects we provide.
@@ -43,7 +43,7 @@ The following per-cell data columns are included for each cell, calculated using
 | `subsets_mito_sum`      | UMI count of mitochondrial genes                                                                                                                                                              |
 | `subsets_mito_detected` | Number of mitochondrial genes detected                                                                                                                                                        |
 | `subsets_mito_percent`  | Percent of all UMI counts assigned to mitochondrial genes                                                                                                                                     |
-| `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., CITE-seq)                                                                                                             |
+| `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., ADT data from CITE-seq)                                                                                                             |
 
 The following additional per-cell data columns are included in both the `filtered` and `processed` objects.
 These columns include metrics calculated by [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected to predict low-quality cells.
@@ -54,7 +54,8 @@ See the description of the {ref}`processed gene expression data <processing_info
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).  |
-| `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200; if CITE-seq is present, the alternative experiment `discard` column is `TRUE`). All cells labeled as `Remove` were removed prior to writing the `_processed.rds` file, and therefore all cells found in the `_processed.rds` file will be labeled `Keep`. |
+ `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200 |
+| `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
 
 ### Gene information and metrics
 
@@ -99,9 +100,10 @@ expt_metadata <- metadata(sce)
 | `filtering_method`  | The method used for cell filtering. One of `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. Only present for `filtered` objects |
 | `umi_cutoff`        | The minimum UMI count per cell used as a threshold for removing empty droplets. Only present for `filtered` objects where the `filtering_method` is `UMI cutoff` |
 | `prob_compromised_cutoff`        | The minimum cutoff for the probability of a cell being compromised, as calculated by `miQC`. Only present for `filtered` objects |
-| `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`. If CITE-seq data is also present, this will also indicate the ADT filtering method as `cleanTagCounts`, e.g. `miQC;cleanTagCounts`. Only present for `filtered` objects.   |
+| `scpca_filter_method`        | Method used by the Data Lab to filter low quality cells prior to normalization. Either `miQC` or `Minimum_gene_cutoff`.  |
+| `adt_scpca_filter_method`        | If CITE-seq was performed, method used by the Data Lab to identify cells to be filtered prior to normalization, based on ADT-level information. Either `cleanTagCounts with isotype controls` or `cleanTagCounts without isotype controls`, if controls are present or absent, respectively.  |
 | `min_gene_cutoff`        | The minimum cutoff for the number of unique genes detected per cell. Only present for `filtered` objects |
-| `normalization`        | The method used for normalization of raw counts. Either `deconvolution`, described in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7), or  `log-normalization`. Only present for `processed` objects |
+| `normalization`        | The method used for normalization of raw RNA counts. Either `deconvolution`, described in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7), or  `log-normalization`. Only present for `processed` objects |
 | `highly_variable_genes`        | A list of highly variable genes used for dimensionality reduction, determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects |
 
 ### Dimensionality reduction results
@@ -124,29 +126,31 @@ The following command can be used to access the UMAP results:
 reducedDim(sce,"UMAP")
 ```
 
-## Additional SingleCellExperiment components for CITE-seq libraries
+## Additional SingleCellExperiment components for ADT (CITE-seq) libraries
 
-CITE-seq data, when present, is included within the `SingleCellExperiment` as an "Alternative Experiment" named `"CITEseq"` , which can be accessed with the following command:
+ADT data from CITE-seq experiments, when present, is included within the `SingleCellExperiment` as an "Alternative Experiment" named `"adt"` , which can be accessed with the following command:
 
 ```r
-altExp(sce, "CITEseq")
+altExp(sce, "adt")
 ```
 
 Within this, the main expression matrix is again found in the `counts` assay and the normalized expression matrix is found in the `logcounts` assay.
+!!!!!!!! TODO: not everything is normalized. !!!!!!!!!!!
+
 For each assay, each column corresponds to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponds to an antibody derived tag (ADT).
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
 
-The following additional per-cell data columns for the CITE-seq data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).
+The following additional per-cell data columns for the ADT data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).
 
 | Column name                | Contents                                          |
 | -------------------------- | ------------------------------------------------- |
-| `altexps_CITEseq_sum`      | UMI count for CITE-seq ADTs                       |
-| `altexps_CITEseq_detected` | Number of ADTs detected per cell (ADT count > 0 ) |
-| `altexps_CITEseq_percent`  | Percent of `total` UMI count from ADT reads       |
+| `altexps_adt_sum`      | UMI count for CITE-seq ADTs                       |
+| `altexps_adt_detected` | Number of ADTs detected per cell (ADT count > 0 ) |
+| `altexps_adt_percent`  | Percent of `total` UMI count from ADT reads       |
 
 
-In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `colData` of the `"CITEseq"` alternative experiment, accessed with `colData(altExp(sce, "CITEseq"))`.
+In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `colData` of the `"adt"` alternative experiment, accessed with `colData(altExp(sce, "adt"))`.
 
 | Column name                | Contents                                          |
 | -------------------------- | ------------------------------------------------- |
@@ -161,7 +165,7 @@ In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`]
 Metrics for each of the ADTs assayed can be found as a `DataFrame` stored as `rowData` within the alternative experiment:
 
 ```r
-adt_info <- rowData(altExp(sce, "CITEseq"))
+adt_info <- rowData(altExp(sce, "adt"))
 ```
 
 This data frame contains the following columns with statistics for each ADT:
@@ -170,13 +174,13 @@ This data frame contains the following columns with statistics for each ADT:
 | ----------- | -------------------------------------------------------------- |
 | `mean`      | Mean ADT count across all cells/droplets                       |
 | `detected`  | Percent of cells in which the ADT was detected (ADT count > 0 ) |
-| `target_type` | Whether each ADT is a `target`, `neg_control`, or `pos_control`. This column will be empty if target information is unknown. |
+| `target_type` | Whether each ADT is a target (`target`), negative/isotype control (`neg_control`), or positive control (`pos_control`). If this information was not provided, all ADTs will have been considered targets and thusly labeled. |
 
-Finally, additional metadata for the CITE-seq data processing can be found in the metadata slot of the alternative experiment.
+Finally, additional metadata for ADT processing can be found in the metadata slot of the alternative experiment.
 This metadata slot has the same contents as the [parent experiment metadata](#experiment-metadata), along with one additional field, `ambient_profile`, which holds a list of representing the ambient concentrations of each ADT.
 
 ```r
-citeseq_metadata <- metadata(altExp(sce, "CITEseq"))
+adt_metadata <- metadata(altExp(sce, "adt"))
 ```
 
 ## Additional SingleCellExperiment components for multiplexed libraries


### PR DESCRIPTION
Closes #112 
This PR updates `sce_file_contents.md` and `processing_information.md` to reflect our shift in ADT filtering strategy. I also updated some phrasing (which I feel both ways about?) to say "negative/isotype control" instead of either negative or isotype, to cover more ground... Phrasing feedback welcome here!

In these files and `faq.md`, I also changed some wording around to refer more to ADT counts, not CITE-seq counts, and similar. I updated associated rel links where appropriate but this can definitely use some more 👀 !

