### PR TITLE
Update `getting_started` with ADT post-processing 

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -131,7 +131,7 @@ These metrics can be used to directly filter the `SingleCellExperiment` object b
 If you are planning to filter low quality cells using such thresholds, we encourage you to read more about the various metrics and plot the distribution of each metric before deciding on which cells to exclude.
 The [Quality Control chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.13/OSCA.basic/quality-control.html#quality-control) provides a nice guide to checking diagnostic plots and then choosing cutoffs.
 
-If you have ADT data from a CITE-seq experiment, please refer to the section [Special considerations for CITE-seq experiments](#special-considerations-for-cite-seq-experiments) below for information on how to filter cells based on ADT-level statistics.
+If you have ADT data from a CITE-seq experiment, please refer to the section [Special considerations for CITE-seq experiments](#special-considerations-for-cite-seq-experiments) below for information on how to filter cells based on ADT counts.
 
 ### Normalization
 
@@ -157,8 +157,6 @@ Here we provide more resources on understanding normalization in single-cell RNA
 - [Hemberg lab scRNA-seq course section on normalization methods](https://www.singlecellcourse.org/basic-quality-control-qc-and-exploration-of-scrna-seq-datasets.html#normalization-theory)
 - [Stegle _et al._ (2015) Computational and analytical challenges in single-cell transcriptomics](https://doi.org/10.1038/nrg3833).  Includes a discussion of normalization and technical variance in scRNA-seq.
 - [Lun _et al._ (2016) Pooling across cells to normalize single-cell RNA sequencing data with many zero counts](https://doi.org/10.1186/s13059-016-0947-7)
-
-If you have ADT data from a CITE-seq experiment, please refer to the section [Special considerations for CITE-seq experiments](#special-considerations-for-cite-seq-experiments) below for information on how to normalize ADT counts.
 
 ### Dimensionality Reduction
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -241,9 +241,9 @@ raw_adt_counts <- counts(altExp(processed_sce))
 normalized_adt_counts <- logcounts(altExp(processed_sce))
 ```
 
-It is important to be aware that the `SingleCellExperiment` object in the `processed.rds` file was not filtered based on ADT counts.
+Be aware that the `SingleCellExperiment` object in the `processed.rds` file was not filtered based on ADT counts.
 The `adt_scpca_filter` column indicates which cells should be removed before proceeding with downstream analyses of the ADT data, as determined by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-Specifically, this process identified cells with high levels of ambient concentration and/or, if available, high levels of negative/isotype control ADTs for removal.
+Specifically, this process identified cells with high levels of ambient contamination and/or high levels of negative control ADTs (if available).
 Cells are labeled either as `"Keep"` (cells to retain) or `"Remove"` (cells to filter out).
 
 To filter cells based on this column, use the following command:
@@ -253,7 +253,7 @@ To filter cells based on this column, use the following command:
 processed_sce <- processed_sce[, which(processed_sce$adt_scpca_filter == "Keep")]
 ```
 
-It is also important to be aware that the normalized ADT expression matrix only contains values for cells labeled as `"Keep"` in the `adt_scpca_filter` column.
+The normalized ADT expression matrix only contains values for cells labeled as `"Keep"` in the `adt_scpca_filter` column.
 Any cells labeled `"Remove"` have `NA` values in the normalized expression matrix (see {ref}`processed adt data <processing_information:Processed ADT data>` for more details).
 
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -267,21 +267,12 @@ filtered_sce <- filtered_sce[, which(filtered_sce$adt_scpca_filter == "Keep")]
 
 You can also filter cells out based on your own criteria, but regardless we do recommend filtering before proceeding to normalization and downstream analyses.
 In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can also be used for filtering.
-You can access these statistics with the following (see {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` )
+You can access these statistics as follows (see {ref}`Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags) <sce_file_contents:Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags)>` for more details on the available columns):
 
 ```r
 # View the alternative experiment's colData slot
 colData(altExp(filtered_sce))
 ```
-
-Note that the filtering information provided in the `adt_scpca_filter` column was taken from the `discard` column in the `colData`:
-
-```r
-# View the discard column in colData, but print
-# only the first 6 values for easier viewing
-head( colData(altExp(filtered_sce))$discard )
-```
-
 
 Here are some additional resources that can be used for working with ADT counts from CITE-seq experiments:
 - [Integrating with Protein Abundance, Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/integrating-with-protein-abundance.html)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -242,9 +242,12 @@ raw_adt_counts <- counts(altExp(processed_sce))
 normalized_adt_counts <- logcounts(altExp(processed_sce))
 ```
 
-Be aware that the `SingleCellExperiment` object in the `processed.rds` file has been filtered to remove low-quality cells based on RNA expression and is not filtered based on ADT counts.
-The `adt_scpca_filter` column indicates which cells should be removed before proceeding with downstream analyses of the ADT data, as determined by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-Specifically, this process identified cells with high levels of ambient contamination and/or high levels of negative control ADTs (if available).
+Be aware that the `SingleCellExperiment` object in the `processed.rds` file has been filtered to remove low-quality cells based on RNA expression but has not been filtered based on ADT counts.
+
+### Filtering cells based on ADT quality control
+
+The `adt_scpca_filter` column indicates which cells should be removed before proceeding with downstream analyses of the ADT data, as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
+This process identified cells with high levels of ambient contamination and/or high levels of negative control ADTs (if available).
 Cells are labeled either as `"Keep"` (cells to retain) or `"Remove"` (cells to filter out).
 
 To filter cells based on this column, use the following command:
@@ -254,26 +257,20 @@ To filter cells based on this column, use the following command:
 processed_sce <- processed_sce[, which(processed_sce$adt_scpca_filter == "Keep")]
 ```
 
-The normalized ADT expression matrix only contains values for cells labeled as `"Keep"` in the `adt_scpca_filter` column.
-Any cells labeled `"Remove"` have `NA` values in the normalized expression matrix (see {ref}`processed adt data <processing_information:Processed ADT data>` for more details).
+Note that the normalized ADT expression matrix only contains values for cells labeled as `"Keep"` in the `adt_scpca_filter` column.
+Any cells labeled `"Remove"` have `NA` values in the normalized expression matrix (see {ref}`Processed ADT Data <processing_information:Processed ADT data>` for more details).
 
+If you are working with the `filtered.rds` file, you can perform the same filtering:
 
-### Filtering cells based on ADT quality control
-
-To perform the same filtering as we recommended above for the `processed.rds` file, you can use the following command:
 ```r
 # Filter cells based on ADT QC statistics
 filtered_sce <- filtered_sce[, which(filtered_sce$adt_scpca_filter == "Keep")]
 ```
 
-You can also filter cells out based on your own criteria, but regardless we do recommend filtering before proceeding to normalization and downstream analyses.
-In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can also be used for filtering.
-You can access these statistics as follows (see {ref}`Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags) <sce_file_contents:Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags)>` for more details on the available columns):
+Alternatively, you can also filter cells out based on your own criteria.
+Quality-control statistics calculated by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the `colData` slot of the `altExp` (`colData(altExp(filtered_sce))`), as described in {ref}`Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags) <sce_file_contents:Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags)>`.
+We recommend filtering out these low-quality cells before proceeding with ADT normalization and downstream analyses.
 
-```r
-# View the alternative experiment's colData slot
-colData(altExp(filtered_sce))
-```
 
 Here are some additional resources that can be used for working with ADT counts from CITE-seq experiments:
 - [Integrating with Protein Abundance, Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/integrating-with-protein-abundance.html)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -223,7 +223,8 @@ Here are some resources that can be used to get you started working with `AnnDat
 ## Special considerations for CITE-seq experiments
 
 
-If you have ADT data from a CITE-seq experiment, you can use the following commands to access raw and normalized ADT expression matrices in the `processed.rds` file object:
+If the dataset that you have downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in the `altExp` of the `SingleCellExperiment` object in the `processed.rds` file.
+The following commands can be used to access the ADT expression matrices:
 
 ```r
 # the raw ADT counts matrix
@@ -234,7 +235,8 @@ raw_adt_counts <- counts(altExp(processed_sce))
 normalized_adt_counts <- logcounts(altExp(processed_sce))
 ```
 
-It is important to be aware that the `SingleCellExperiment` object in the `processed.rds` file was not filtered based on ADT counts, but information that can be used for filtering is  available in the `adt_scpca_filter` column.
+It is important to be aware that the `SingleCellExperiment` object in the `processed.rds` file was not filtered based on ADT counts.
+The `adt_scpca_filter` column indicates which cells should be removed before proceeding with downstream analyses of the ADT data.
 Cells are labeled either as `"Keep"` (cells to retain) or `"Remove"` (cells to filter out).
 
 To filter cells based on this column, use the following command:
@@ -245,7 +247,7 @@ processed_sce <- processed_sce[, which(processed_sce$adt_scpca_filter == "Keep")
 
 It is also important to be aware that the normalized ADT expression matrix only contains values for cells labeled as `"Keep"` in the `adt_scpca_filter` column.
 Any cells labeled `"Remove"` have `NA` values normalized expression matrix (see
-{ref}`processed cite-seq data <processing_information:Processed CITE-seq data>` for more details).
+{ref}`processed adt data <processing_information:Processed ADT data>` for more details).
 
 As dimension reduction requires all known values (i.e., no `NA`s), filtering cells as shown above is critical before proceeding to downstream analyses on ADT counts.
 
@@ -267,7 +269,7 @@ processed_sce <- scater::runUMAP(altExp(processed_sce))
 In both the `filtered.rds` and `processed.rds` files, cells are flagged for removal based on ADT-level QC statistics in the alternative experiment's `discard` column as calculated by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
 This column contains values `FALSE` for cells that should not be removed and `TRUE` for cells that should be removed.
 
-To filter cells based on ADT counts, for example in the `filtered.rds` object, use the following commands:
+If starting with the `filtered.rds` file instead, cells will need to be filtered based on ADT counts using the following commands:
 
 ```r
 # First, you can see cells should be removed (`TRUE`) vs. kept (`FALSE`)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -221,7 +221,8 @@ Here are some resources that can be used to get you started working with `AnnDat
 
 ## Special considerations for CITE-seq experiments
 
-If the dataset that you have downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in an `altExp` named `"adt"` of the `SingleCellExperiment` object in the `processed.rds` file:
+If the dataset you downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in as an `altExp` named `"adt"`.
+We recommend working with the `SingleCellExperiment` objects stored in the `processed.rds` files as those files contain additional quality control metrics for the CITE-seq experiment:
 
 ```r
 # View the ADT alternative experiment
@@ -241,7 +242,7 @@ raw_adt_counts <- counts(altExp(processed_sce))
 normalized_adt_counts <- logcounts(altExp(processed_sce))
 ```
 
-Be aware that the `SingleCellExperiment` object in the `processed.rds` file was not filtered based on ADT counts.
+Be aware that the `SingleCellExperiment` object in the `processed.rds` file has been filtered to remove low-quality cells based on RNA expression and is not filtered based on ADT counts.
 The `adt_scpca_filter` column indicates which cells should be removed before proceeding with downstream analyses of the ADT data, as determined by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
 Specifically, this process identified cells with high levels of ambient contamination and/or high levels of negative control ADTs (if available).
 Cells are labeled either as `"Keep"` (cells to retain) or `"Remove"` (cells to filter out).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -247,22 +247,31 @@ altExp(filtered_sce)$discard
 altExp(processed_sce)$discard
 ```
 
-In the `processed.rds` object specifically, this information is also recorded as values "Remove" and "Keep":
+To filter cells based on this column, use the following command, for example on `filtered_sce`:
+```r
+# Filter cells based on ADT-level QC statistics
+filtered_sce <- filtered_sce[, -which(altExp(filtered_sce)$discard)]
+```
+
+In the `processed.rds` object specifically, this information is also recorded as values `"Remove"` and `"Keep"`:
 
 ```r
 # See which cells should be removed vs. kept in `processed.rds`
 processed_sce$adt_scpca_filter
 ```
+
+To filter cells based on this column, use the following command:
+```r
+# Filter cells based on ADT-level QC statistics
+processed_sce <- processed_sce[, which(processed_sce$adt_scpca_filter ==  "Keep")]
+```
+
+
 ### Normalizing ADT counts
 
 The `filtered.rds` object contains a raw ADT counts matrix, but not a matrix of log normalized ADT expression.
-To perform normalization yourself, we first recommend filtering cells flagged for removal by ADT-level QC statistics to reduce the chances of normalization failing:
+To perform normalization yourself, we first recommend filtering cells flagged for removal by ADT-level QC statistics to reduce the chances of normalization failing, as described above.
 
-```r
-# Filter cells based on ADT-level QC statistics to
-#  prepare for normalization
-filtered_sce <- filtered_sce[, adt_scpca_filter == "Keep"]
-```
 
 Normalization can then be performed with `scuttle` and `scater`:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -264,7 +264,7 @@ In both the `filtered.rds` and `processed.rds` files, quality-control statistics
 To perform the same filtering as we recommended above for the `processed.rds` file, you can use the following command:
 ```r
 # Filter cells based on ADT QC statistics
-filtered_sce <- filtered_sce[, -which(altExp(filtered_sce)$discard)]
+filtered_sce <- filtered_sce[, which(filtered_sce$adt_scpca_filter == "Keep")]
 ```
 
 You can also filter cells out based on your own criteria, but regardless we do recommend filtering before proceeding to normalization and downstream analyses.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -260,21 +260,7 @@ processed_sce <- processed_sce[, which(processed_sce$adt_scpca_filter == "Keep")
 It is also important to be aware that the normalized ADT expression matrix only contains values for cells labeled as `"Keep"` in the `adt_scpca_filter` column.
 Any cells labeled `"Remove"` have `NA` values in the normalized expression matrix (see {ref}`processed adt data <processing_information:Processed ADT data>` for more details).
 
-As dimension reduction requires all known values (i.e., no `NA`s), filtering cells as shown above is critical before proceeding to downstream analyses on ADT counts.
 
-To perform principal components analysis (PCA) on the ADT counts, use the following `scater` command _after_ filtering has been performed:
-
-```r
-# Calculate PCA on the ADT counts
-processed_sce <- scater::runPCA(altExp(processed_sce))
-```
-
-To perform UMAP on this resulting PCA matrix, use the following `scater` command:
-
-```r
-# Calculate UMAP on the ADT counts
-processed_sce <- scater::runUMAP(altExp(processed_sce))
-```
 ### Filtering cells based on ADT quality control
 
 In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can be used for filtering.
@@ -285,30 +271,7 @@ To perform the same filtering as we recommended above for the `processed.rds` fi
 filtered_sce <- filtered_sce[, -which(altExp(filtered_sce)$discard)]
 ```
 
-You can also filter cells out based on your own criteria, but regardless we do recommend filtering before proceeding to normalization.
-
-### Normalizing ADT counts
-
-The `filtered.rds` object contains a raw ADT counts matrix, but not a matrix of log normalized ADT expression.
-To perform normalization yourself, we first recommend filtering cells using the `filtered_sce$discard` column, as shown above, to reduce the chances of normalization failing as described in
-{ref}`processed adt data <processing_information:Processed ADT data>`.
-
-Normalization can then be performed with `scuttle` and `scater`:
-
-```r
-# Calculate size factors for use in ADT normalization,
-# using the previously-calculated ambient profile
-altExp(filtered_sce) <- scuttle::computeMedianFactors(
-  altExp(filtered_sce),
-  reference = metadata(altExp(filtered_sce))$ambient_profile
-)
-
-# Normalize and log transform
-# This will only succeed if all size factors calculated above are positive
-altExp(filtered_sce) <- scater::logNormCounts(altExp(filtered_sce))
-```
-
-You can now proceed with dimension reduction (PCA and UMAP) using the same approach as described above for the `processed.rds` object.
+You can also filter cells out based on your own criteria, but regardless we do recommend filtering before proceeding to normalization and downstream analyses.
 
 
 Here are some additional resources that can be used for working with ADT counts from CITE-seq experiments:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -224,7 +224,16 @@ Here are some resources that can be used to get you started working with `AnnDat
 ## Special considerations for CITE-seq experiments
 
 
-If the dataset that you have downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in an `altExp` of the `SingleCellExperiment` object in the `processed.rds` file.
+If the dataset that you have downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in an `altExp` named `"adt"` of the `SingleCellExperiment` object in the `processed.rds` file:
+
+```r
+# View the ADT alternative experiment
+altExp(processed_sce)
+
+# You can also explicitly specify the altexp's name:
+altExp(processed_sce, "adt")
+```
+
 The following commands can be used to access the ADT expression matrices:
 
 ```r
@@ -268,18 +277,15 @@ processed_sce <- scater::runUMAP(altExp(processed_sce))
 ```
 ### Filtering cells based on ADT quality control
 
-In both the `filtered.rds` and `processed.rds` files, cells are flagged for removal based on ADT-level QC statistics in the alternative experiment's `discard` column as calculated by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-This column contains values `FALSE` for cells that should not be removed and `TRUE` for cells that should be removed.
+In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can be used for filtering.
 
-If starting with the `filtered.rds` file instead, cells will need to be filtered based on ADT counts using the following commands:
-
+To perform the same filtering as we recommended above for the `processed.rds` file, you can use the following command:
 ```r
-# First, you can see cells should be removed (`TRUE`) vs. kept (`FALSE`)
-altExp(filtered_sce)$discard
-
 # Filter cells based on ADT QC statistics
 filtered_sce <- filtered_sce[, -which(altExp(filtered_sce)$discard)]
 ```
+
+You can also filter cells out based on your own criteria, but regardless we do recommend filtering before proceeding to normalization.
 
 ### Normalizing ADT counts
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -125,12 +125,13 @@ The following columns are added by `scuttle::addPerCellQCMetrics()` and can be f
 | `subsets_mito_sum`      | UMI count of mitochondrial genes                                                                                                                                                              |
 | `subsets_mito_detected` | Number of mitochondrial genes detected                                                                                                                                                        |
 | `subsets_mito_percent`  | Percent of all UMI counts assigned to mitochondrial genes                                                                                                                                     |
-| `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., CITE-seq)                                                                                                             |
+| `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., ADT data from CITE-seq)                                                                                                             |
 
 These metrics can be used to directly filter the `SingleCellExperiment` object based on informed thresholds.
 If you are planning to filter low quality cells using such thresholds, we encourage you to read more about the various metrics and plot the distribution of each metric before deciding on which cells to exclude.
 The [Quality Control chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.13/OSCA.basic/quality-control.html#quality-control) provides a nice guide to checking diagnostic plots and then choosing cutoffs.
 
+See the other section below if you have CITE-seq experiment and want to do more filtering based on ADTs.
 ### Normalization
 
 The provided data contains unnormalized raw counts.
@@ -215,6 +216,17 @@ Here are some resources that can be used to get you started working with `AnnDat
 - [Preprocessing and clustering tutorial in scanpy](https://scanpy-tutorials.readthedocs.io/en/latest/pbmc3k.html)
 - [Converting directly from R to Python](https://theislab.github.io/scanpy-in-R/#converting-from-r-to-python)
 - [Homepage for scanpy tutorials](https://scanpy.readthedocs.io/en/latest/tutorials.html)
+
+
+## Special considerations for CITE-seq experiments
+
+These have ADT in the altExp which you can also filter.
+We did this with cleanTagCounts, using provided negatives if you had them, and an ambient profile that's stored in the metadata.
+You can filter based on the `adt_scpca_filter` column (which has "Keep"/"Remove" for corresponding `FALSE`/`TRUE` in the altexp colData `discard` column).
+
+Normalization is still up for grabs in the field overall and we recommend OSCA for different ideas.
+We recommend median-based normalization which is usually ok for these non-sparse counts.
+This will fail if any size fators are 0 so you should filter cells based on `adt_scpca_filter` first to have the best chance of success here.
 
 ## Special considerations for multiplexed samples
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -223,7 +223,6 @@ Here are some resources that can be used to get you started working with `AnnDat
 
 ## Special considerations for CITE-seq experiments
 
-
 If the dataset that you have downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in an `altExp` named `"adt"` of the `SingleCellExperiment` object in the `processed.rds` file:
 
 ```r

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -236,14 +236,15 @@ Here are some resources that can be used to get you started working with `AnnDat
 
 ### Filtering cells based on ADT quality control
 
-The `SingleCellExperiment` objects stored in both the `filtered.rds` and the `processed.rds` have not been filtered based on ADT-level statistics, but both objects contain indicator variables to quickly perform this filtering.
+The `SingleCellExperiment` objects stored in both the `filtered.rds` and the `processed.rds` files have not been filtered based on ADT-level statistics, but both objects contain indicator variables to quickly perform this filtering.
 
-In both objects, you can see cells flagged for removal based on ADT-level QC statistics in the alternative experiment's `discard` column, where `TRUE` indicates the cell should be removed.
+In both objects, you can see cells flagged for removal based on ADT-level QC statistics in the alternative experiment's `discard` column as calculated by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html), where `TRUE` indicates the cell should be removed.
 
 ```r
 # See which cells should be removed (`TRUE`) vs. kept (`FALSE`)
-# This information is in both `filtered.rds` and `processed.rds`
-altExp(sce)$discard
+# This column is in both `filtered.rds` and `processed.rds`:
+altExp(filtered_sce)$discard
+altExp(processed_sce)$discard
 ```
 
 In the `processed.rds` object specifically, this information is also recorded as values "Remove" and "Keep":
@@ -259,7 +260,7 @@ To perform normalization yourself, we first recommend filtering cells flagged fo
 
 ```r
 # Filter cells based on ADT-level QC statistics to
-# prepare for normalization
+#  prepare for normalization
 filtered_sce <- filtered_sce[, adt_scpca_filter == "Keep"]
 ```
 
@@ -274,10 +275,11 @@ altExp(filtered_sce) <- scuttle::computeMedianFactors(
 )
 
 # Normalize and log transform
+# This step will only succeed if all size factors calculated above are positive
 altExp(filtered_sce) <- scater::logNormCounts(altExp(filtered_sce))
 ```
 
-A normalized expression matrix is also provided in the `processed.rds` object, specifically for all cells which are indicated as `"Keep"` in the `processed_sce$adt_scpca_filter` column:
+A normalized expression matrix is also provided in the `processed.rds` object, containing values for all cells which are indicated as `"Keep"` in the `processed_sce$adt_scpca_filter` column and `NA` for all cells indicated as `"Remove"`:
 
 ```r
 # Access log normalized ADT expression matrix

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -236,7 +236,8 @@ normalized_adt_counts <- logcounts(altExp(processed_sce))
 ```
 
 It is important to be aware that the `SingleCellExperiment` object in the `processed.rds` file was not filtered based on ADT counts.
-The `adt_scpca_filter` column indicates which cells should be removed before proceeding with downstream analyses of the ADT data.
+The `adt_scpca_filter` column indicates which cells should be removed before proceeding with downstream analyses of the ADT data, as determined by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
+Specifically, this process identified cells with high levels of ambient concentration and/or, if available, high levels of negative/isotype control ADTs for removal.
 Cells are labeled either as `"Keep"` (cells to retain) or `"Remove"` (cells to filter out).
 
 To filter cells based on this column, use the following command:
@@ -283,7 +284,7 @@ filtered_sce <- filtered_sce[, -which(altExp(filtered_sce)$discard)]
 
 The `filtered.rds` object contains a raw ADT counts matrix, but not a matrix of log normalized ADT expression.
 To perform normalization yourself, we first recommend filtering cells using the `filtered_sce$discard` column, as shown above, to reduce the chances of normalization failing as described in
-{ref}`processed cite-seq data <processing_information:Processed CITE-seq data>`.
+{ref}`processed adt data <processing_information:Processed ADT data>`.
 
 Normalization can then be performed with `scuttle` and `scater`:
 
@@ -299,6 +300,8 @@ altExp(filtered_sce) <- scuttle::computeMedianFactors(
 # This will only succeed if all size factors calculated above are positive
 altExp(filtered_sce) <- scater::logNormCounts(altExp(filtered_sce))
 ```
+
+You can now proceed with dimension reduction (PCA and UMAP) using the same approach as described above for the `processed.rds` object.
 
 
 Here are some additional resources that can be used for working with ADT counts from CITE-seq experiments:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -259,8 +259,6 @@ Any cells labeled `"Remove"` have `NA` values in the normalized expression matri
 
 ### Filtering cells based on ADT quality control
 
-In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can be used for filtering.
-
 To perform the same filtering as we recommended above for the `processed.rds` file, you can use the following command:
 ```r
 # Filter cells based on ADT QC statistics
@@ -268,6 +266,21 @@ filtered_sce <- filtered_sce[, which(filtered_sce$adt_scpca_filter == "Keep")]
 ```
 
 You can also filter cells out based on your own criteria, but regardless we do recommend filtering before proceeding to normalization and downstream analyses.
+In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can also be used for filtering.
+You can access these statistics with the following (see {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` )
+
+```r
+# View the alternative experiment's colData slot
+colData(altExp(filtered_sce))
+```
+
+Note that the filtering information provided in the `adt_scpca_filter` column was taken from the `discard` column in the `colData`:
+
+```r
+# View the discard column in colData, but print
+# only the first 6 values for easier viewing
+head( colData(altExp(filtered_sce))$discard )
+```
 
 
 Here are some additional resources that can be used for working with ADT counts from CITE-seq experiments:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -132,6 +132,7 @@ If you are planning to filter low quality cells using such thresholds, we encour
 The [Quality Control chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.13/OSCA.basic/quality-control.html#quality-control) provides a nice guide to checking diagnostic plots and then choosing cutoffs.
 
 If you have ADT data from a CITE-seq experiment, please refer to the section [Special considerations for CITE-seq experiments](#special-considerations-for-cite-seq-experiments) below for information on how to filter cells based on ADT-level statistics.
+
 ### Normalization
 
 The provided data contains unnormalized raw counts.
@@ -223,7 +224,7 @@ Here are some resources that can be used to get you started working with `AnnDat
 ## Special considerations for CITE-seq experiments
 
 
-If the dataset that you have downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in the `altExp` of the `SingleCellExperiment` object in the `processed.rds` file.
+If the dataset that you have downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in an `altExp` of the `SingleCellExperiment` object in the `processed.rds` file.
 The following commands can be used to access the ADT expression matrices:
 
 ```r
@@ -241,14 +242,14 @@ Specifically, this process identified cells with high levels of ambient concentr
 Cells are labeled either as `"Keep"` (cells to retain) or `"Remove"` (cells to filter out).
 
 To filter cells based on this column, use the following command:
+
 ```r
 # Filter cells based on ADT QC statistics
 processed_sce <- processed_sce[, which(processed_sce$adt_scpca_filter == "Keep")]
 ```
 
 It is also important to be aware that the normalized ADT expression matrix only contains values for cells labeled as `"Keep"` in the `adt_scpca_filter` column.
-Any cells labeled `"Remove"` have `NA` values normalized expression matrix (see
-{ref}`processed adt data <processing_information:Processed ADT data>` for more details).
+Any cells labeled `"Remove"` have `NA` values in the normalized expression matrix (see {ref}`processed adt data <processing_information:Processed ADT data>` for more details).
 
 As dimension reduction requires all known values (i.e., no `NA`s), filtering cells as shown above is critical before proceeding to downstream analyses on ADT counts.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -277,7 +277,7 @@ processed_sce <- scater::runUMAP(altExp(processed_sce))
 ```
 ### Filtering cells based on ADT quality control
 
-In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can be used for filtering.
+In both the `filtered.rds` and `processed.rds` files, quality-control statistics calculated by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) are provided in the alternative experiment's `colData` and can be used for filtering.
 
 To perform the same filtering as we recommended above for the `processed.rds` file, you can use the following command:
 ```r

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -265,7 +265,7 @@ processed_sce <- scater::runUMAP(altExp(processed_sce))
 ### Filtering cells based on ADT quality control
 
 In both the `filtered.rds` and `processed.rds` files, cells are flagged for removal based on ADT-level QC statistics in the alternative experiment's `discard` column as calculated by [`DropletUtils::CleanTagCounts()](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html).
-This column contains values `FALSE` for cells that should not be removed, and `TRUE` for cells that should be removed.
+This column contains values `FALSE` for cells that should not be removed and `TRUE` for cells that should be removed.
 
 To filter cells based on ADT counts, for example in the `filtered.rds` object, use the following commands:
 
@@ -278,7 +278,6 @@ filtered_sce <- filtered_sce[, -which(altExp(filtered_sce)$discard)]
 ```
 
 ### Normalizing ADT counts
-
 
 The `filtered.rds` object contains a raw ADT counts matrix, but not a matrix of log normalized ADT expression.
 To perform normalization yourself, we first recommend filtering cells using the `filtered_sce$discard` column, as shown above, to reduce the chances of normalization failing as described in

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -240,7 +240,6 @@ The following commands can be used to access the ADT expression matrices:
 raw_adt_counts <- counts(altExp(processed_sce))
 
 # the log normalized ADT counts matrix
-# if this value is NULL, it means normalization failed
 normalized_adt_counts <- logcounts(altExp(processed_sce))
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -221,7 +221,7 @@ Here are some resources that can be used to get you started working with `AnnDat
 
 ## Special considerations for CITE-seq experiments
 
-If the dataset you downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored in as an `altExp` named `"adt"`.
+If the dataset you downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices are stored as an `altExp` named `"adt"`.
 We recommend working with the `SingleCellExperiment` objects stored in the `processed.rds` files as those files contain additional quality control metrics for the CITE-seq experiment:
 
 ```r


### PR DESCRIPTION
Closes #113 

This PR updates `getting_started.md` with information on how users can get started with filtered and/or processed ADT data. I described how users can filter cells based on ADT stats and normalize ADT counts, with considerations for both `filtered.rds` and `processed.rds`. I included two resources links - OSCA and a Seurat vignette.

Something I thought about but didn't do (yet?) is expand the table with `subsets_mito_sum` to indicate the `subsets_adt_*` QC stats, since this seemed out of scope for that section (even though it's a thing that might get returned if there is a CITEseq altexp).

Let me know where we could use a little more or less detail! 