### PR TITLE
Little docs fixes

### DIFF
--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -239,7 +239,7 @@ Demultiplexing analysis adds the following additional fields to the `colData(sce
 Each demultiplexing method generates additional statistics specific to the method that you may wish to access, including probabilities, alternative calls, and potential doublet information.
 
 For methods that rely on the HTO data, these statistics are found in the `colData(altExp(sce, "cellhash"))` data frame;
-`DropletUtils::hashedDrops` statistics have the prefix `hashedDrops_` and `Seurat::HTODemux` statistics have the prefix `HTODemux`.
+`DropletUtils::hashedDrops()` statistics have the prefix `hashedDrops_` and `Seurat::HTODemux()` statistics have the prefix `HTODemux`.
 
 Genetic demultiplexing statistics are found in the main `colData(sce)` data frame, with the prefix `vireo_`.
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -55,7 +55,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | `prob_compromised`      | Probability that a cell is compromised (i.e., dead or damaged), as calculated by `miQC`                                                                                                       |
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells).  |
 | `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
-| `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
+| `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
 
 ### Gene information and metrics
 
@@ -139,7 +139,7 @@ Within this, the main expression matrix is again found in the `counts` assay and
 For each assay, each column corresponds to a cell or droplet (in the same order as the parent `SingleCellExperiment`) and each row corresponds to an antibody derived tag (ADT).
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
-Note that only cells which are denoted as "Keep" in  the `colData(sce)$adt_scpca_filter` column (as described in #cell-metrics) have normalized expression values in the `logcounts` assay, and all other cells are assigned `NA` values.
+Note that only cells which are denoted as "Keep" in  the `colData(sce)$adt_scpca_filter` column (as described [above](#cell-metrics)) have normalized expression values in the `logcounts` assay, and all other cells are assigned `NA` values.
 However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances, in which case there will be no `logcounts` normalized expression matrix present in the alternative experiment.
 
 The following additional per-cell data columns for the ADT data can be found in the main `colData` data frame (accessed with `colData(sce)` [as above](#cell-metrics)).


### PR DESCRIPTION
Closes #122 

Happily there weren't really any broken xrefs, just 1 as described in #122 :tada:
I fixed that one and then added a couple `()` where needed at the end of functions.