### PR TITLE
Add docs for clustering

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -44,12 +44,14 @@ HVGs
 intronic
 introns
 isotype
+Jaccard
 Kaminow
 Marioni
 Pearson
 pre
 pseudocount
 pseudogenes
+Louvain
 Lun
 miQC
 oligo

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -70,6 +70,7 @@ These HVGs are then used as input to principal component analysis, and the top 5
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
 [Graph-based clustering](http://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph) is also performed, using by default the Louvain algorithm with 15 nearest neighbors, using Jaccard weighting.
+
 ## ADT quantification from CITE-seq experiments
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -69,6 +69,7 @@ The log-normalized counts are used to model variance of each gene prior to selec
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
+[Graph-based clustering](http://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph) is also performed, using by default the Louvain algorithm with 15 nearest neighbors, using Jaccard weighting.
 ## ADT quantification from CITE-seq experiments
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -69,7 +69,7 @@ The log-normalized counts are used to model variance of each gene prior to selec
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
-[Graph-based clustering](http://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph) is also performed, using by default the Louvain algorithm with 20 nearest neighbors, using Jaccard weighting.
+[Graph-based clustering](http://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph) is also performed, using the Louvain algorithm with 20 nearest neighbors and Jaccard weighting.
 
 ## ADT quantification from CITE-seq experiments
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -69,7 +69,7 @@ The log-normalized counts are used to model variance of each gene prior to selec
 These HVGs are then used as input to principal component analysis, and the top 50 principal components are selected.
 Finally, these principal components are used to calculate the [UMAP (Uniform Manifold Approximation and Projection)](http://bioconductor.org/books/3.13/OSCA.basic/dimensionality-reduction.html#uniform-manifold-approximation-and-projection) embeddings.
 
-[Graph-based clustering](http://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph) is also performed, using by default the Louvain algorithm with 15 nearest neighbors, using Jaccard weighting.
+[Graph-based clustering](http://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph) is also performed, using by default the Louvain algorithm with 20 nearest neighbors, using Jaccard weighting.
 
 ## ADT quantification from CITE-seq experiments
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -57,7 +57,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
 | `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
 
-The `processed` SCE object has one additional `colData` column reflecting cluster assignments:
+The `processed` object has one additional `colData` column reflecting cluster assignments:
 
 | Column name             | Contents                                              |
 | ----------------------- | ----------------------------------------------------- |

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -61,7 +61,7 @@ The `processed` object has one additional `colData` column reflecting cluster as
 
 | Column name             | Contents                                              |
 | ----------------------- | ----------------------------------------------------- |
-| `clusters`  | Cell cluster identify identified by graph-based clustering |
+| `clusters`  | Cell cluster identity identified by graph-based clustering |
 
 
 ### Gene information and metrics

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -57,6 +57,13 @@ See the description of the {ref}`processed gene expression data <processing_info
 | `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
 | `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
 
+The `processed` SCE object has one additional `colData` column reflecting cluster assignments:
+
+| Column name             | Contents                                              |
+| ----------------------- | ----------------------------------------------------- |
+| `clusters`  | Cell cluster identify identified by graph-based clustering |
+
+
 ### Gene information and metrics
 
 Gene information and metrics calculated from the RNA-seq expression data are stored as a `DataFrame` in the `rowData` slot, with the Ensembl ID as the names of the rows.
@@ -106,6 +113,8 @@ expt_metadata <- metadata(sce)
 | `normalization`        | The method used for normalization of raw RNA counts. Either `deconvolution`, described in [Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7), or `log-normalization`. Only present for `processed` objects |
 | `adt_normalization`        | If CITE-seq was performed, the method used for normalization of raw ADT counts. Either `median-based` or  `log-normalization`, as explained in {ref}`processed ADT data section <processing_information:Processed ADT data>`. Only present for `processed` objects |
 | `highly_variable_genes`        | A list of highly variable genes used for dimensionality reduction, determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects |
+| `cluster_algorithm` | The algorithm used to perform graph-based clustering of cells. Only present for `processed` objects |
+| `cluster_nn`        | The nearest neighbor parameter value used for the graph-based clustering. Only present for `processed` objects |
 
 ### Dimensionality reduction results
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -114,6 +114,7 @@ expt_metadata <- metadata(sce)
 | `adt_normalization`        | If CITE-seq was performed, the method used for normalization of raw ADT counts. Either `median-based` or  `log-normalization`, as explained in {ref}`processed ADT data section <processing_information:Processed ADT data>`. Only present for `processed` objects |
 | `highly_variable_genes`        | A list of highly variable genes used for dimensionality reduction, determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects |
 | `cluster_algorithm` | The algorithm used to perform graph-based clustering of cells. Only present for `processed` objects |
+| `cluster_weighting` | The weighting approach used during graph-based clustering. Only present for `processed` objects |
 | `cluster_nn`        | The nearest neighbor parameter value used for the graph-based clustering. Only present for `processed` objects |
 
 ### Dimensionality reduction results


### PR DESCRIPTION
Closes #128 

This PR adds documentation for the graph-based clustering that is heading into `scpca-nf`.

For now I'm opening this as a draft PR, since the details added to `docs/processing_information.md` _may_ change as https://github.com/AlexsLemonade/scpca-nf/pull/405 gets wrapped up. Once that other PR that is actually adding the clustering workflow is all set, I will update here as needed and mark as ready for review.