### PR TITLE
Include description of sample metadata present in SCE object 

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -87,7 +87,7 @@ The `single_cell_metadata.tsv` file is a tab-separated table with one row per li
 | `technology`      | 10x kit used to process library                                |
 | `filtered_cell_count` | Number of cells after filtering with `emptyDrops`          |
 | `submitter_id`    | Original sample identifier from submitter                      |
-| `participant_id`  | Original participant id, required when there are multiple samples from the same participant, optional for all other samples                                                                        |
+| `participant_id`  | Original participant id                                        |
 | `submitter`       | Submitter name/id                                              |
 | `age`             | Age at time sample was obtained                                |
 | `sex`             | Sex of patient that the sample was obtained from               |

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -106,6 +106,8 @@ expt_metadata <- metadata(sce)
 | `usa_mode`          | Boolean indicating whether quantification was done using `alevin-fry` USA mode                                                 |
 | `af_num_cells`      | Number of cells reported by `alevin-fry`                                                                                       |
 | `tech_version`      | A string indicating the technology and version used for the single-cell library, such as 10Xv2, 10Xv3, or 10Xv3.1              |
+| `assay_ontology_term_id` | A string indicating the [Experimental Factor Ontology](https://www.ebi.ac.uk/ols/ontologies/efo) term id associated with the `tech_version`  |
+| `seq_unit`         | `cell` for single-cell samples or `nucleus` for single-nucleus samples                                                          |
 | `transcript_type`   | Transcripts included in gene counts: `spliced` for single-cell samples and `unspliced` for single-nuclei                       |
 | `miQC_model`        | The model object that `miQC` fit to the data and was used to calculate `prob_compromised`. Only present for `filtered` objects |
 | `filtering_method`  | The method used for cell filtering. One of `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. Only present for `filtered` objects |
@@ -126,6 +128,35 @@ expt_metadata <- metadata(sce)
 | `singler_reference_label` | If cell typing with `SingleR` was performed, the name of the label in the reference dataset used for annotation. Only present for `processed` objects |
 | `cellassign_predictions` | If cell typing with `CellAssign` was performed, the full matrix of predictions across cells and cell types. Only present for `processed` objects |
 | `cellassign_reference` | If cell typing with `CellAssign` was performed, is the organ/tissue type for which marker genes were obtained from `PanglaoDB`. Only present for `processed` objects |
+
+### Sample metadata
+
+Relevant sample metadata is available as a data frame stored in the `metadata(sce)$sample_metadata` slot of the `SingleCellExperiment` object.
+The following columns are included in the sample metadata data frame for all libraries.
+
+| Column name   | Contents                                                         |
+| ------------- | ---------------------------------------------------------------- |
+| `sample_id`   | Sample ID in the form `SCPCS000000`                            |
+| `library_id`   | Library ID in the form `SCPCL000000`                             |
+| `donor_id`  | Unique id corresponding to the donor from which the sample was obtained (equivalent to `particpant_id` included in `single_cell_metadata.tsv`) |
+| `submitter_id`    | Original sample identifier from submitter                      |
+| `submitter`       | Submitter name/id                                              |
+| `age`             | Age at time sample was obtained                                |
+| `sex`             | Sex of patient that the sample was obtained from               |
+| `diagnosis`       | Tumor type                                                     |
+| `subdiagnosis`    | Subcategory of diagnosis or mutation status (if applicable)    |
+| `tissue_location` | Where in the body the tumor sample was located                 |
+| `disease_timing`  | At what stage of disease the sample was obtained, either diagnosis or recurrence |
+| `organism`         | The organism the sample was obtained from (e.g., `Homo_sapiens`) |
+| `development_stage_ontology_term_id` | `HsapDv` ontology term indicating developmental stage - for _Homo sapiens_ either one of the terms for [1 - 11 months old](https://ontobee.org/search?ontology=HSAPDV&keywords=month-old&submit=Search+terms) or for [older than 12 months old](https://ontobee.org/search?ontology=HSAPDV&keywords=year-old&submit=Search+terms). If unavailable, `unknown` is used.  |
+| `sex_ontology_term_id` | [PATO](http://obofoundry.org/ontology/pato.html) term referring to the sex of the sample, must be a child of [`PATO:0001894`](https://ontobee.org/ontology/PATO?iri=http://purl.obolibrary.org/obo/PATO_0001894). If unavailable, `unknown` is used.  |
+| `organism_ontology_id` | NCBI taxonomy term for organism, e.g. [`NCBITaxon:9606`](https://ontobee.org/ontology/NCBITaxon?iri=http://purl.obolibrary.org/obo/NCBITaxon_9606). |
+| `self_reported_ethnicity_ontology_term_id` | For _Homo sapiens_, a [`Hancestro` term](http://obofoundry.org/ontology/hancestro.html). `multiethnic` indicates more than one ethnicity is reported. `unknown` indicates unavailable ethnicity and `NA` is used for all other organisms.  |
+| `disease_ontology_term_id` | [`MONDO`](http://obofoundry.org/ontology/mondo.html) term indicating disease type. [`PATO:0000461`](https://ontobee.org/ontology/PATO?iri=http://purl.obolibrary.org/obo/PATO_0000461) indicates normal or healthy tissue. If unavailable, `NA` is used.  |
+| `tissue_ontology_term_id`| [`UBERON`](http://obofoundry.org/ontology/uberon.html) term indicating tissue of origin. If unavailable, `NA` is used. |
+
+For some libraries, the sample metadata may also include additional metadata specific to the disease type and experimental design of the project.
+Examples of this include treatment or outcome.
 
 ### Dimensionality reduction results
 


### PR DESCRIPTION
Closes #146 
Stacked on #153 

This PR modifies the current SCE contents to include a table listing all of the sample metadata columns that are present in `metadata(sce)$sample_metadata`. I added a row for listing the `sample_metadata` in the table with the `metadata(sce)` contents, but then I also made a separate section just for the sample metadata. Here, I added a table showing the expected columns in the sample metadata table that's stored in the object. I also added a note that there may be additional columns depending on the project. 

I added in the `seq_unit` and `assay_ontology_term_id` to the metadata list since those had not been added yet. 

While working on this, I also removed the note about `participant_id` only being filled in for participants that contain multiple samples. Those are now present for all of our samples. 