### PR TITLE
Update FAQs to account for AnnData

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -68,8 +68,8 @@ The filtered counts file is further filtered to remove low quality cells, such a
 This file contains the raw and normalized counts data for cell barcodes that have passed both levels of filtering.
 In addition to the counts matrices, the `SingleCellExperiment` or `AnnData` object stored in the file includes the results of dimensionality reduction using both principal component analysis (PCA) and UMAP.
 
-See {ref}`Single-cell gene expression file contents <sce_file_contents:Single-cell gene expression file contents>` for more information about the contents of the `SingleCellExperiment` objects and the included statistics and metadata.
-See also {ref}`Using the provided RDS files in R <faq:how do i use the provided RDS files in r?>`.
+See {ref}`Single-cell gene expression file contents <sce_file_contents:Single-cell gene expression file contents>` for more information about the contents of the `SingleCellExperiment` and `AnnData` objects and the included statistics and metadata.
+See also {ref}`Using the provided RDS files in R <faq:how do i use the provided RDS files in r?>` and {ref}`Using the provided HDF5 files in Python <faq:how do i use the provided HDF5 files in python?>`.
 
 ## QC Report
 
@@ -99,7 +99,8 @@ The `single_cell_metadata.tsv` file is a tab-separated table with one row per li
 Additional metadata may also be included, specific to the disease type and experimental design of the project.
 Examples of this include treatment or outcome.
 Metadata pertaining to processing will also be available in this table and inside of the `SingleCellExperiment` object.
-See the {ref}`Experiment metadata <sce_file_contents:experiment metadata>` section for more information on metadata columns that can be found in this file as well as inside the `SingleCellExperiment` object.
+See the {ref}`SingleCellExperiment experiment metadata <sce_file_contents:singlecellexperiment experiment metadata>` section for more information on metadata columns that can be found in the `SingleCellExperiment` object.
+See the {ref}`AnnData experiment metadata <sce_file_contents:anndata experiment metadata>` section for more information on metadata columns that can be found in the `AnnData` object.
 
 For projects with bulk RNA-seq data, the `bulk_metadata.tsv` file will be included for project downloads.
 This file will contain fields equivalent to those found in the `single_cell_metadata.tsv` related to processing the sample, but will not contain patient or disease specific metadata (e.g. `age`, `sex`, `diagnosis`, `subdiagnosis`, `tissue_location`, or `disease_timing`).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,7 +22,8 @@ Recent reports from others support our findings.
 
 ## How do I use the provided RDS files in R?
 
-We are providing the gene expression data to you as a [`SingleCellExperiment` object](http://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html) in an RDS file.
+If you would like to work with the gene expression data in R, you will need to choose the option for downloading the data as a [`SingleCellExperiment` object](http://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html).
+This download includes RDS files that can be directly read into R.
 
 _Note: You will need to install and load the [`SingleCellExperiment` package](https://bioconductor.org/packages/3.13/bioc/html/SingleCellExperiment.html) from Bioconductor to work with the provided files._
 
@@ -30,8 +31,28 @@ To read in the RDS files you can use the `readRDS` command in base R.
 
 ```r
 library(SingleCellExperiment)
-scpca_sample <- readRDS("SCPCL000000_filtered.rds")
+scpca_sample <- readRDS("SCPCL000000_processed.rds")
 ```
+
+A full description of the contents of the `SingleCellExperiment` object can be found in the section on {ref}`Components of a SingleCellExperiment object <sce_file_contents:Components of a singlecellexperiment object>`.
+For more information on working with the RDS files, see {ref}`Getting started with an ScPCA dataset <getting_started:Getting started with an scpca dataset>`.
+
+## How do I use the provided HDF5 files in Python?
+
+If you would like to work with the gene expression data in Python, you will need to choose the option for downloading the data as an [`AnnData` object](https://anndata.readthedocs.io/en/latest/index.html).
+This download includes HDF5 files that can be directly read into Python.
+
+_Note: You will need to install the [`AnnData` package](https://anndata.readthedocs.io/en/latest/index.html) to work with the provided files._
+
+To read in the HDF5 files you can use the `readh5ad` function from the `AnnData` package.
+
+```python
+import anndata
+scpca_sample = anndata.readh5ad(file = "SCPCL000000_processed_rna.hdf5")
+```
+
+A full description of the contents of the `AnnData` object can be found in the section on {ref}`Components of an AnnData object <sce_file_contents:Components of an anndata object>`.
+For more information on working with the RDS files, see {ref}`Getting started with an ScPCA dataset <getting_started:Getting started with an scpca dataset>`.
 
 ## What is the difference between samples and libraries?
 
@@ -98,7 +119,7 @@ You can find the [function for generating a QC report](https://github.com/AlexsL
 
 ## What if I want to use Seurat instead of Bioconductor?
 
-The files available for download contain [`SingleCellExperiment` objects](http://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html).
+The RDS files available for download contain [`SingleCellExperiment` objects](http://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html).
 If desired, these can be converted into Seurat objects.
 
 You will need to [install and load the `Seurat` package](https://satijalab.org/seurat/articles/install.html) to work with Seurat objects.
@@ -148,63 +169,3 @@ adt_assay@meta.features <- adt_row_metadata
 # add altExp from SingleCellExperiment as second assay to Seurat
 seurat_object[["ADT"]] <- adt_assay
 ```
-
-## What if I want to use Python instead of R?
-
-We provide single-cell and single-nuclei gene expression data as RDS files, which must be opened in R to view the contents.
-If you prefer to work in Python, there are a variety of ways of converting the count data to Python-compatible formats.
-We have found that one of the more efficient is conversion via the 10x format using [`DropletUtils::write10xCounts()`](https://rdrr.io/bioc/DropletUtils/man/write10xCounts.html).
-Note that you will need to install the [`DropletUtils` package](https://www.bioconductor.org/packages/devel/bioc/html/DropletUtils.html) to use this function.
-
-When used as described below, `DropletUtils::write10xCounts()` will output three files to a new directory, following the format used by Cell Ranger 3.0 (and later):
-- the counts matrix in sparse matrix format - `matrix.mtx.gz`
-- the row names, or gene names, saved as a TSV - `features.tsv.gz`
-- the column names, or cell barcodes, saved as a TSV - `barcodes.tsv.gz`
-
-```r
-library(SingleCellExperiment)
-
-# read in the RDS file to be converted
-sce <- readRDS("SCPCL000000_filtered.rds")
-
-# write counts to 10x format and save to a folder named "SCPCL000000-rna"
-DropletUtils::write10xCounts("SCPCL000000-rna", counts(sce),
-                             barcodes = colnames(sce),
-                             gene.id = rownames(sce),
-                             gene.symbol = rowData(sce)$gene_symbol,
-                             version = "3")
-
-```
-
-If a library has associated ADT data, you will have to save that separately.
-
-```r
-# write ADT counts to 10x format
-DropletUtils::write10xCounts("SCPCL000000-adt", counts(altExp(sce)),
-                             barcodes = colnames(altExp(sce)),
-                             gene.id = rownames(altExp(sce)),
-                             gene.type = "Antibody Capture",
-                             version = "3")
-
-```
-
-These files can then be directly read into Python using the [`scanpy` package](https://scanpy.readthedocs.io/en/stable/), creating an [`AnnData` object](https://anndata.readthedocs.io/en/latest/index.html).
-Note that you will need to [install the `scanpy` package](https://scanpy.readthedocs.io/en/stable/installation.html).
-
-```python
-import scanpy as sc
-
-#read in 10x formatted files
-rna_file_directory = "SCPCL000000-rna"
-anndata_object = sc.read_10x_mtx(rna_file_directory)
-
-adt_file_directory = "SCPCL000000-adt"
-adt_anndata = sc.read_10x_mtx(adt_file_directory)
-
-# append ADT anndata to RNA-seq anndata
-anndata_object["ADT"] = adt_anndata.to_df()
-```
-
-It should be noted that in this conversion the `colData`, `rowData`, and metadata that are found in the original `SingleCellExperiment` objects will not be retained.
-If you would like to include this data, you could write out each table separately and load them manually in Python.
-Alternatively, you might be interested in this [reference from the authors of `scanpy`](https://theislab.github.io/scanpy-in-R/#converting-from-r-to-python) discussing a different approach to  conversion using Rmarkdown notebooks and the `reticulate` package to directly convert `SingleCellExperiment` object components to `AnnData` object components without writing files locally.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -52,7 +52,7 @@ scpca_sample = anndata.readh5ad(file = "SCPCL000000_processed_rna.hdf5")
 ```
 
 A full description of the contents of the `AnnData` object can be found in the section on {ref}`Components of an AnnData object <sce_file_contents:Components of an anndata object>`.
-For more information on working with the RDS files, see {ref}`Getting started with an ScPCA dataset <getting_started:Getting started with an scpca dataset>`.
+For more information on working with the HDF5 files, see {ref}`Getting started with an ScPCA dataset <getting_started:Getting started with an scpca dataset>`.
 
 ## What is the difference between samples and libraries?
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -11,7 +11,7 @@ Note that multiplexed sample libraries are only available as `SingleCellExperime
 
 Below we present some details about the specific contents of the objects we provide.
 
-## Components of a `SingleCellExperiment` object
+## Components of a SingleCellExperiment object
 
 Before getting started, we highly encourage you to familiarize yourself with the general `SingleCellExperiment` object structure and functions available as part of the [`SingleCellExperiment` package](https://bioconductor.org/packages/3.17/bioc/html/SingleCellExperiment.html) from Bioconductor.
 
@@ -22,7 +22,7 @@ library(SingleCellExperiment)
 sce <- readRDS("SCPCL000000_processed.rds")
 ```
 
-### `SingleCellExperiment` expression counts
+### SingleCellExperiment expression counts
 
 The `counts` assay of the `SingleCellExperiment` object for single-cell and single-nuclei experiments (for all provided file types) contains the primary RNA-seq expression data as integer counts.
 The data is stored as a sparse matrix, and each column represents a cell or droplet, each row a gene.
@@ -33,7 +33,7 @@ The `counts` assay can be accessed with the following R code:
 counts(sce) # counts matrix
 ```
 
-### `SingleCellExperiment` cell metrics
+### SingleCellExperiment cell metrics
 
 Cell metrics calculated from the RNA-seq expression data are stored as a `DataFrame` in the `colData` slot, with the cell barcodes as the names of the rows.
 
@@ -75,7 +75,7 @@ Further, if cell type annotation was performed, there will be additional columns
 | `cellassign_celltype_annotation`  | If cell typing with `CellAssign` was performed, the annotated cell type. Cells labeled as `"other"` are those which `CellAssign` could not confidently annotate  |
 | `cellassign_max_prediction`  | If cell typing with `CellAssign` was performed, the annotation's prediction score (probability)  |
 
-### `SingleCellExperiment` gene information and metrics
+### SingleCellExperiment gene information and metrics
 
 Gene information and metrics calculated from the RNA-seq expression data are stored as a `DataFrame` in the `rowData` slot, with the Ensembl ID as the names of the rows.
 
@@ -92,7 +92,7 @@ Metrics were calculated using the [`scuttle::addPerFeatureQCMetrics`](https://rd
 | `mean`        | Mean count across all cells/droplets                             |
 | `detected`    | Percent of cells in which the gene was detected (gene count > 0 ) |
 
-### `SingleCellExperiment` experiment metadata
+### SingleCellExperiment experiment metadata
 
 Metadata associated with {ref}`data processing <processing_information:Processing information>` is included in the `metadata` slot as a list.
 
@@ -137,7 +137,7 @@ metadata(sce) # experiment metadata
 | `cellassign_predictions` | If cell typing with `CellAssign` was performed, the full matrix of predictions across cells and cell types. Only present for `processed` objects |
 | `cellassign_reference` | If cell typing with `CellAssign` was performed, is the organ/tissue type for which marker genes were obtained from `PanglaoDB`. Only present for `processed` objects |
 
-### `SingleCellExperiment` sample metadata
+### SingleCellExperiment sample metadata
 
 Relevant sample metadata is available as a data frame stored in the `metadata(sce)$sample_metadata` slot of the `SingleCellExperiment` object.
 Each row in the data frame will correspond to a sample present in the library.
@@ -167,7 +167,7 @@ The following columns are included in the sample metadata data frame for all lib
 For some libraries, the sample metadata may also include additional metadata specific to the disease type and experimental design of the project.
 Examples of this include treatment or outcome.
 
-### `SingleCellExperiment` dimensionality reduction results
+### SingleCellExperiment dimensionality reduction results
 
 In the RDS file containing the processed `SingleCellExperiment` object only (`_processed.rds`), the `reducedDim` slot of the object will be occupied with both principal component analysis (`PCA`) and `UMAP` results.
 For all other files, the `reducedDim` slot will be empty as no dimensionality reduction was performed.
@@ -187,7 +187,7 @@ The following command can be used to access the UMAP results:
 reducedDim(sce, "UMAP")
 ```
 
-### Additional `SingleCellExperiment` components for CITE-seq libraries (with ADT tags)
+### Additional SingleCellExperiment components for CITE-seq libraries (with ADT tags)
 
 ADT data from CITE-seq experiments, when present, is included within the `SingleCellExperiment` as an "Alternative Experiment" named `"adt"` , which can be accessed with the following command:
 
@@ -244,7 +244,7 @@ This metadata slot has the same contents as the [parent experiment metadata](#si
 metadata(altExp(sce, "adt")) # adt metadata
 ```
 
-### Additional `SingleCellExperiment` components for multiplexed libraries
+### Additional SingleCellExperiment components for multiplexed libraries
 
 Multiplexed libraries will contain a number of additional components and fields.
 
@@ -303,7 +303,7 @@ For methods that rely on the HTO data, these statistics are found in the `colDat
 
 Genetic demultiplexing statistics are found in the main `colData(sce)` data frame, with the prefix `vireo_`.
 
-## Components of an `AnnData` object
+## Components of an AnnData object
 
 Before getting started, we highly encourage you to familiarize yourself with the general `AnnData` object structure and functions available as part of the [`AnnData` package](https://anndata.readthedocs.io/en/latest/index.html).
 For the most part, the `AnnData` objects that we provide are formatted to match the expected data format for [`CELLxGENE`](https://cellxgene.cziscience.com/) following [schema version `3.0.0`](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md).
@@ -315,7 +315,7 @@ import anndata
 adata_object = anndata.read_h5ad("SCPCL000000_processed_rna.hdf5")
 ```
 
-### `AnnData` expression counts
+### AnnData expression counts
 
 The data matrix, `X`, of the `AnnData` object for single-cell and single-nuclei experiments contains the primary RNA-seq expression data as integer counts in both the unfiltered (`_unfiltered_rna.hdf5`) and filtered (`_filtered_rna.hdf5`) objects.
 The data is stored as a sparse matrix, and each column represents a cell or droplet, each row a gene.
@@ -334,7 +334,7 @@ adata_object.raw.X # raw count matrix
 adata_object.X # normalized count matrix
 ```
 
-### `AnnData` cell metrics
+### AnnData cell metrics
 
 Cell metrics calculated from the RNA-seq expression data are stored as a `pandas.DataFrame` in the `.obs` slot, with the cell barcodes as the names of the rows.
 
@@ -372,7 +372,7 @@ The `AnnData` object also includes the following additional cell-level metadata 
 | `is_primary_data` | Set to `FALSE` for all libraries to reflect that all libraries were obtained from external investigators. Required by `CELLxGENE`.             |
 
 
-### `AnnData` gene information and metrics
+### AnnData gene information and metrics
 
 Gene information and metrics calculated from the RNA-seq expression data are stored as a `pandas.DataFrame` in the `.var` slot, with the Ensembl ID as the names of the rows.
 
@@ -390,7 +390,7 @@ The `AnnData` object also includes the following additional gene-level metadata 
 | `is_feature_filtered` | Boolean indicating if the gene or feature is filtered out in the normalized matrix but is present in the raw matrix     |
 
 
-### `AnnData` experiment metadata
+### AnnData experiment metadata
 
 Metadata associated with {ref}`data processing <processing_information:Processing information>` is included in the `.uns` slot as a list.
 
@@ -410,7 +410,7 @@ The `AnnData` object also includes the following additional items in the `.uns` 
 | `schema_version` | CZI schema version used for `AnnData` formatting |
 
 
-### `AnnData` dimensionality reduction results
+### AnnData dimensionality reduction results
 
 The HDF5 file containing the processed `AnnData` object (`_processed_rna.hdf5`) contains a slot `.obsm` with both principal component analysis (`X_PCA`) and UMAP (`X_UMAP`) results.
 For all other HDF5 files, the `.obsm` slot will be empty as no dimensionality reduction was performed.
@@ -424,7 +424,7 @@ adata_object.obsm["X_PCA"] # pca results
 adata_object.obsm["X_UMAP"] # umap results
 ```
 
-### Additional `AnnData` components for CITE-seq libraries (with ADT tags)
+### Additional AnnData components for CITE-seq libraries (with ADT tags)
 
 ADT data from CITE-seq experiments, when present, is available as a separate `AnnData` object (HDF5 file).
 All files containing ADT data will contain the `_adt.hdf5` suffix.


### PR DESCRIPTION
Closes #149 
Closes #147 
Stacked on #162 

I removed the FAQ on "what if I want to work with python" and replaced it with a FAQ on how to work with the downloaded HDF5 files. I decided to mirror what we provide for working with RDS files, and thought it didn't make sense to have both FAQs there. 

I also expanded the RDS FAQ to include some links to both the getting started and the file contents sections, since I think both are helpful. I did the same in the HDF5 section. 

While I was here, I did some checking on the links to make sure that they still work, given some of the header changes we've made previously. I noticed some were broken because I used code formatting in the headings, but now I remember why we didn't have that before. The links don't work with the code formatting, so I also removed that. 