### PR TITLE
Update SCE contents and processing with cell type information

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -54,6 +54,7 @@ Pearson
 pre
 pseudocount
 pseudogenes
+Looney
 Louvain
 Lun
 miQC
@@ -81,3 +82,4 @@ UMI
 UMIs
 unspliced
 xenografts
+Zhang

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -87,7 +87,7 @@ During annotation, we additionally include an `"other"` cell type that does not 
 As a consequence, cells which `CellAssign` cannot confidently annotate from the full marker gene list are labeled as `"other"`.
 
 **Note:** For some libraries, cell type annotations were provided from the group that submitted the original data.
-If this is the case, the cell type annotations obtained from the submitter will be present in addition to cell type annotation performed with `SingleR` and `CellAssign`.
+In these cases, the cell type annotations obtained from the submitter will be present in addition to cell type annotation performed with `SingleR` and `CellAssign`.
 
 ## ADT quantification from CITE-seq experiments
 

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -75,8 +75,8 @@ Finally, these principal components are used to calculate the [UMAP (Uniform Man
 
 We perform cell type annotation with two complementary methods, where possible:
 
-- [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), a reference-based cell type annotation method
-- [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene--based cell type annotation method
+- [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), a reference-based cell type annotation method ([Looney _et al._ 2019](https://doi.org/10.1038/s41590-018-0276-y))
+- [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene--based cell type annotation method ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1))
 
 For `SingleR` annotation, we identify an appropriate reference dataset from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) and train the classification model to use ontology IDs for annotation.
 Cells which `SingleR` cannot confidently assign are labeled as `NA`.
@@ -85,6 +85,7 @@ For `CellAssign` annotation, we identify an appropriate set of marker genes for 
 We combine these marker genes with all "immune cell" `PanglaoDB` marker genes to create a full marker gene list for for cell type annotation.
 During annotation, we additionally include an `"other"` cell type that does not express any of these marker genes.
 As a consequence, cells which `CellAssign` cannot confidently annotate from the full marker gene list are labeled as `"other"`.
+
 ## ADT quantification from CITE-seq experiments
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -86,6 +86,9 @@ We combine these marker genes with all "immune cell" `PanglaoDB` marker genes to
 During annotation, we additionally include an `"other"` cell type that does not express any of these marker genes.
 As a consequence, cells which `CellAssign` cannot confidently annotate from the full marker gene list are labeled as `"other"`.
 
+**Note:** For some libraries, cell type annotations were provided from the group that submitted the original data.
+If this is the case, the cell type annotations obtained from the submitter will be present in addition to cell type annotation performed with `SingleR` and `CellAssign`.
+
 ## ADT quantification from CITE-seq experiments
 
 CITE-seq libraries with reads from antibody-derived tags (ADTs) were also quantified using  [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html) and [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/), rounded to integer values.

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -51,7 +51,6 @@ The following per-cell data columns are included for each cell, calculated using
 | `subsets_mito_detected` | Number of mitochondrial genes detected                                                                                                                                                        |
 | `subsets_mito_percent`  | Percent of all UMI counts assigned to mitochondrial genes                                                                                                                                     |
 | `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., ADT data from CITE-seq)                                                                                                             |
-| `submitter_annotation` | If available, cell type annotations obtained from the group that submitted the original data. Cells that are not classified by the submitter are labeled as "Unclassified cell" |
 
 The following additional per-cell data columns are included in both the `filtered` and `processed` objects.
 These columns include metrics calculated by [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected to predict low-quality cells.
@@ -64,6 +63,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells)  |
 | `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
 | `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
+| `submitter_annotation` | If available, cell type annotations obtained from the group that submitted the original data. Cells that are not classified by the submitter are labeled as "Unclassified cell" |
 
 
 The `processed` object has one additional `colData` column reflecting cluster assignments.

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -51,6 +51,7 @@ The following per-cell data columns are included for each cell, calculated using
 | `subsets_mito_detected` | Number of mitochondrial genes detected                                                                                                                                                        |
 | `subsets_mito_percent`  | Percent of all UMI counts assigned to mitochondrial genes                                                                                                                                     |
 | `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., ADT data from CITE-seq)                                                                                                             |
+| `submitter_annotation` | If available, cell type annotations obtained from the submitter. Cells that are not classified by the submitter are labeled as "Unclassified cell" |
 
 The following additional per-cell data columns are included in both the `filtered` and `processed` objects.
 These columns include metrics calculated by [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected to predict low-quality cells.
@@ -63,6 +64,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells)  |
 | `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
 | `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
+
 
 The `processed` object has one additional `colData` column reflecting cluster assignments.
 Further, if cell type annotation was performed, there will be additional columns representing annotation results in the `processed` object's `colData`, as described in the {ref}`cell type annotation processing section <processing_information:Cell type annotation>`.
@@ -130,12 +132,11 @@ metadata(sce) # experiment metadata
 | `cluster_algorithm` | The algorithm used to perform graph-based clustering of cells. Only present for `processed` objects |
 | `cluster_weighting` | The weighting approach used during graph-based clustering. Only present for `processed` objects |
 | `cluster_nn`        | The nearest neighbor parameter value used for the graph-based clustering. Only present for `processed` objects |
-| `celltype_methods` | If cell type annotation was performed, a vector of the methods used for annotation. May include `"singler"` and/or `"cellassign"`. Only present for `processed` objects |
+| `celltype_methods` | If cell type annotation was performed, a vector of the methods used for annotation. May include `"submitter"`, `"singler"` and/or `"cellassign"`. If submitter cell-type annotations are available, this will be present in filtered objects, otherwise this item is only present for `processed` objects |
 | `singler_results` | If cell typing with `SingleR` was performed, the full result object returned by `SingleR` annotation. Only present for `processed` objects |
-| `singler_reference_name` | If cell typing with `SingleR` was performed, the name of the [`celldex`](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) reference dataset used for annotation. Only present for `processed` objects |
-| `singler_reference_label` | If cell typing with `SingleR` was performed, the name of the label in the reference dataset used for annotation. Only present for `processed` objects |
+| `singler_reference` | If cell typing with `SingleR` was performed, the name of the [`celldex`](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) reference dataset used for annotation. Only present for `processed` objects |
 | `cellassign_predictions` | If cell typing with `CellAssign` was performed, the full matrix of predictions across cells and cell types. Only present for `processed` objects |
-| `cellassign_reference` | If cell typing with `CellAssign` was performed, is the organ/tissue type for which marker genes were obtained from `PanglaoDB`. Only present for `processed` objects |
+| `cellassign_reference` | If cell typing with `CellAssign` was performed, the name of the organ/tissue type for which marker genes were obtained from `PanglaoDB`. Only present for `processed` objects |
 
 ### SingleCellExperiment sample metadata
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -51,7 +51,7 @@ The following per-cell data columns are included for each cell, calculated using
 | `subsets_mito_detected` | Number of mitochondrial genes detected                                                                                                                                                        |
 | `subsets_mito_percent`  | Percent of all UMI counts assigned to mitochondrial genes                                                                                                                                     |
 | `total`                 | Total UMI count for RNA-seq data and any alternative experiments (i.e., ADT data from CITE-seq)                                                                                                             |
-| `submitter_annotation` | If available, cell type annotations obtained from the submitter. Cells that are not classified by the submitter are labeled as "Unclassified cell" |
+| `submitter_annotation` | If available, cell type annotations obtained from the group that submitted the original data. Cells that are not classified by the submitter are labeled as "Unclassified cell" |
 
 The following additional per-cell data columns are included in both the `filtered` and `processed` objects.
 These columns include metrics calculated by [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html), a package that jointly models proportion of reads belonging to mitochondrial genes and number of unique genes detected to predict low-quality cells.
@@ -132,7 +132,7 @@ metadata(sce) # experiment metadata
 | `cluster_algorithm` | The algorithm used to perform graph-based clustering of cells. Only present for `processed` objects |
 | `cluster_weighting` | The weighting approach used during graph-based clustering. Only present for `processed` objects |
 | `cluster_nn`        | The nearest neighbor parameter value used for the graph-based clustering. Only present for `processed` objects |
-| `celltype_methods` | If cell type annotation was performed, a vector of the methods used for annotation. May include `"submitter"`, `"singler"` and/or `"cellassign"`. If submitter cell-type annotations are available, this will be present in filtered objects, otherwise this item is only present for `processed` objects |
+| `celltype_methods` | If cell type annotation was performed, a vector of the methods used for annotation. May include `"submitter"`, `"singler"` and/or `"cellassign"`. If submitter cell-type annotations are available, this will be present in all objects, otherwise this item is only present for `processed` objects |
 | `singler_results` | If cell typing with `SingleR` was performed, the full result object returned by `SingleR` annotation. Only present for `processed` objects |
 | `singler_reference` | If cell typing with `SingleR` was performed, the name of the [`celldex`](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) reference dataset used for annotation. Only present for `processed` objects |
 | `cellassign_predictions` | If cell typing with `CellAssign` was performed, the full matrix of predictions across cells and cell types. Only present for `processed` objects |

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -73,7 +73,7 @@ Further, if cell type annotation was performed, there will be additional columns
 | ----------------------- | ----------------------------------------------------- |
 | `cluster`  | Cell cluster identity identified by graph-based clustering |
 | `singler_celltype_annotation`  | If cell typing with `SingleR` was performed, the annotated cell type. Cells labeled as `NA` are those which `SingleR` could not confidently annotate |
-| `singler_celltype_ontology`  | If cell typing with `SingleR` was performed, the annotated cell type's ontology ID. Cells labeled as `NA` are those which `SingleR` could not confidently annotate |
+| `singler_celltype_ontology`  | If cell typing with `SingleR` was performed with ontology labels, the annotated cell type's ontology ID. Cells labeled as `NA` are those which `SingleR` could not confidently annotate. |
 | `cellassign_celltype_annotation`  | If cell typing with `CellAssign` was performed, the annotated cell type. Cells labeled as `"other"` are those which `CellAssign` could not confidently annotate  |
 | `cellassign_max_prediction`  | If cell typing with `CellAssign` was performed, the annotation's prediction score (probability)  |
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -135,6 +135,7 @@ metadata(sce) # experiment metadata
 | `celltype_methods` | If cell type annotation was performed, a vector of the methods used for annotation. May include `"submitter"`, `"singler"` and/or `"cellassign"`. If submitter cell-type annotations are available, this metadata item will be present in all objects. Otherwise, this item will only be in `processed` objects |
 | `singler_results` | If cell typing with `SingleR` was performed, the full result object returned by `SingleR` annotation. Only present for `processed` objects |
 | `singler_reference` | If cell typing with `SingleR` was performed, the name of the [`celldex`](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) reference dataset used for annotation. Only present for `processed` objects |
+| `singler_reference_label` | If cell typing with `SingleR` was performed, the name of the label in the reference dataset used for annotation. Only present for `processed` objects |
 | `cellassign_predictions` | If cell typing with `CellAssign` was performed, the full matrix of predictions across cells and cell types. Only present for `processed` objects |
 | `cellassign_reference` | If cell typing with `CellAssign` was performed, the name of the organ/tissue type for which marker genes were obtained from `PanglaoDB`. Only present for `processed` objects |
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -73,7 +73,7 @@ Further, if cell type annotation was performed, there will be additional columns
 | ----------------------- | ----------------------------------------------------- |
 | `cluster`  | Cell cluster identity identified by graph-based clustering |
 | `singler_celltype_annotation`  | If cell typing with `SingleR` was performed, the annotated cell type. Cells labeled as `NA` are those which `SingleR` could not confidently annotate |
-| `singler_celltype_ontology`  | If cell typing with `SingleR` was performed with ontology labels, the annotated cell type's ontology ID. Cells labeled as `NA` are those which `SingleR` could not confidently annotate. |
+| `singler_celltype_ontology`  | If cell typing with `SingleR` was performed with ontology labels, the annotated cell type's ontology ID. Cells labeled as `NA` are those which `SingleR` could not confidently annotate |
 | `cellassign_celltype_annotation`  | If cell typing with `CellAssign` was performed, the annotated cell type. Cells labeled as `"other"` are those which `CellAssign` could not confidently annotate  |
 | `cellassign_max_prediction`  | If cell typing with `CellAssign` was performed, the annotation's prediction score (probability)  |
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -63,7 +63,7 @@ See the description of the {ref}`processed gene expression data <processing_info
 | `miQC_pass`             | Indicates whether the cell passed the default miQC filtering. `TRUE` is assigned to cells with a low probability of being compromised (`prob_compromised` < 0.75) or [sufficiently low mitochondrial content](https://bioconductor.org/packages/release/bioc/vignettes/miQC/inst/doc/miQC.html#preventing-exclusion-of-low-mito-cells)  |
 | `scpca_filter` | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200) |
 | `adt_scpca_filter` | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html)) |
-| `submitter_annotation` | If available, cell type annotations obtained from the group that submitted the original data. Cells that are not classified by the submitter are labeled as "Unclassified cell" |
+| `submitter_celltype_annotation` | If available, cell type annotations obtained from the group that submitted the original data. Cells that the submitter did not annotate are labeled as `NA` |
 
 
 The `processed` object has one additional `colData` column reflecting cluster assignments.
@@ -132,7 +132,7 @@ metadata(sce) # experiment metadata
 | `cluster_algorithm` | The algorithm used to perform graph-based clustering of cells. Only present for `processed` objects |
 | `cluster_weighting` | The weighting approach used during graph-based clustering. Only present for `processed` objects |
 | `cluster_nn`        | The nearest neighbor parameter value used for the graph-based clustering. Only present for `processed` objects |
-| `celltype_methods` | If cell type annotation was performed, a vector of the methods used for annotation. May include `"submitter"`, `"singler"` and/or `"cellassign"`. If submitter cell-type annotations are available, this will be present in all objects, otherwise this item is only present for `processed` objects |
+| `celltype_methods` | If cell type annotation was performed, a vector of the methods used for annotation. May include `"submitter"`, `"singler"` and/or `"cellassign"`. If submitter cell-type annotations are available, this metadata item will be present in all objects. Otherwise, this item will only be in `processed` objects |
 | `singler_results` | If cell typing with `SingleR` was performed, the full result object returned by `SingleR` annotation. Only present for `processed` objects |
 | `singler_reference` | If cell typing with `SingleR` was performed, the name of the [`celldex`](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) reference dataset used for annotation. Only present for `processed` objects |
 | `cellassign_predictions` | If cell typing with `CellAssign` was performed, the full matrix of predictions across cells and cell types. Only present for `processed` objects |


### PR DESCRIPTION
Closes #160 

This PR makes some small adjustments to docs to sync up what we say about cell typing here to where the cell types actually live in the object. 

- I added a link for both SingleR and CellAssign papers to the processing information section on cell type annotation. 
- In that same section, I added a note about submitter annotations. 
- I included the `submitter_annotation` column in the cell metrics section. When adding this in, I chose to add this in the table that mentions items that are in both filtered and processed objects. I think this is the right place since if they are available they will be in all of the objects. 
- I standardized how we refer to the `cellassign_reference` and `singler_reference`. This matches changes made in https://github.com/AlexsLemonade/scpca-nf/pull/510 and https://github.com/AlexsLemonade/scpca-nf/pull/503. 

Please let me know if you think I missed any other areas here. I will update the download section separately as part of #159 and the getting started section as part of #165. 