### PR TITLE
Update CITE-seq section of getting started docs to include AnnData 

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -300,7 +300,7 @@ Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that
 The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.
 
 Note that multiplexed sample libraries are only available as `SingleCellExperiment` objects, and are not currently available as `AnnData` objects.
-If you prefer to work with `AnnData` objects, we recommend using the [`zellkonverter` package](https://bioconductor.org/packages/3.17/bioc/html/zellkonverter.html) to convert the `SingleCellExperiment` object to a HDF5 file containing an `AnnData` object.
+If you prefer to work with `AnnData` objects, we recommend using the [`zellkonverter` package](https://theislab.github.io/zellkonverter/reference/AnnData-Conversion.html) to convert the `SingleCellExperiment` object to a HDF5 file containing an `AnnData` object.
 
 
 Libraries containing multiplexed samples can be initially processed using the same workflow described above including removal of [low quality cells](#quality-control), [normalization](#normalization), and [dimensionality reduction](#dimensionality-reduction).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -219,17 +219,18 @@ Here are some resources that can be used to get you started working with Seurat 
 ## Special considerations for CITE-seq experiments
 
 If the dataset you downloaded contains samples with ADT data from a CITE-seq experiment, the raw and normalized ADT expression matrices will be provided.
+
 For `SingleCellExperiment` objects with ADT data, the ADT expression matrices will be stored as an `altExp` named `"adt"` in the same object containing the RNA expression data.
 
-For `AnnData` objects with ADT data, the ADT expression matrices will be available as three separate `AnnData` objects, an unfiltered object (`_unfiltered_adt.hdf5`), a filtered object (`_filtered_adt.hdf5`), and a processed object (`_processed_adt.hdf5`).
-These files will only contain ADT expression data and do not contain RNA expression data.
+For `AnnData` objects with ADT data, the ADT expression matrices will be provided in separate files corresponding to the same three stages of data processing: an unfiltered object (`_unfiltered_adt.hdf5`), a filtered object (`_filtered_adt.hdf5`), and a processed object (`_processed_adt.hdf5`).
+These files will only contain ADT expression data and not RNA expression data.
 
-We recommend working with the processed objects as those files contain both the raw and normalized ADT expression matrices along with additional quality control metrics for the CITE-seq experiment:
+We recommend working with the processed objects as they contain both the raw and normalized ADT expression matrices along with additional quality control metrics for the CITE-seq experiment.
 To access the ADT expression matrices in `SingleCellExperiment` objects, use the following commands:
 
 ```r
 # View the ADT alternative experiment
-# Note that the altExp name is optional, as we are using the default name "adt"
+# Note that the altExp name is optional, as this is the only altExp present
 altExp(processed_sce, "adt")
 
 # the raw ADT counts matrix
@@ -239,7 +240,7 @@ counts(altExp(processed_sce))
 logcounts(altExp(processed_sce))
 ```
 
-To access the ADT matrices in `AnnData` objects you will need to read in the `_adt.hdf5` file and grab the `raw.X` and `X` matrices as shown below:
+To access the ADT matrices in `AnnData` objects you will first need to read in the `_adt.hdf5` file, and then you can access the `raw.X` and `X` matrices as shown below:
 
 ```python
 import anndata
@@ -253,7 +254,7 @@ adt_adata.raw.X
 adt_adata.X
 ```
 
-Be aware that the processed objects have been filtered to remove low-quality cells based on RNA expression but has not been filtered based on ADT counts.
+Be aware that the processed objects have been filtered to remove low-quality cells based on RNA expression but have not been filtered based on ADT counts.
 
 ### Filtering cells based on ADT quality control
 
@@ -304,7 +305,7 @@ Libraries containing multiplexed samples can be initially processed using the sa
 Demultiplexing can then be used to identify the sample that each cell is from.
 Demultiplexing has already been performed using both [`Seurat::HTODemux`](https://satijalab.org/seurat/reference/htodemux) and [`DropletUtils::hashedDrops`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html).
 For samples where corresponding bulk RNA-sequencing data is available, {ref}`genetic demultiplexing <processing_information:Genetic demultiplexing>` was also conducted.
-The results from demultiplexing using these methods have been summarized and are present in the `colData` of the processed `SingleCellExperiment` object.
+The associated demultiplexing results were summarized and are available in the `colData` of the processed `SingleCellExperiment` object.
 The `hashedDrops_sampleid`, `HTODemux_sampleid`, and `vireo_sampleid` columns in the `colData` report the sample called for each cell by the specified demultiplexing method.
 If a confident call was not made for a cell by the demultiplexing method, the column will have a value of `NA`.
 For more information on how to access the full demultiplexing results, see {ref}`this description of demultiplexing results <sce_file_contents:demultiplexing results>`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -300,7 +300,7 @@ Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that
 The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.
 
 Note that multiplexed sample libraries are only available as `SingleCellExperiment` objects, and are not currently available as `AnnData` objects.
-If you prefer to work with `AnnData` objects, we recommend using the [`zellkonverter` package](https://theislab.github.io/zellkonverter/reference/AnnData-Conversion.html) to convert the `SingleCellExperiment` object to a HDF5 file containing an `AnnData` object.
+If you prefer to work with `AnnData` objects, we recommend using the [`zellkonverter` package](https://theislab.github.io/zellkonverter/reference/AnnData-Conversion.html) to convert the `SingleCellExperiment` object to an HDF5 file containing an `AnnData` object.
 
 
 Libraries containing multiplexed samples can be initially processed using the same workflow described above including removal of [low quality cells](#quality-control), [normalization](#normalization), and [dimensionality reduction](#dimensionality-reduction).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -284,7 +284,7 @@ For `SingleCellExperiment` objects, quality-control statistics calculated by [`D
 
 For `AnnData` objects, these same quality-control statistics are provided in the `obs` slot of the `AnnData` object as described in {ref}`Additional AnnData components for CITE-seq libraries (with ADT tags) <sce_file_contents: Additional AnnData components for CITE-seq libraries (with ADT tags)>`.
 
-We recommend filtering out these low-quality cells before proceeding with ADT normalization and downstream analyses.
+We recommend filtering out these low-quality cells before proceeding with downstream analyses.
 
 Here are some additional resources that can be used for working with ADT counts from CITE-seq experiments:
 - [Integrating with Protein Abundance, Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/integrating-with-protein-abundance.html)
@@ -298,7 +298,9 @@ Here, multiplexed samples refer to samples that have been combined together into
 This means that a single library contains cells or nuclei that correspond to multiple samples.
 Each sample has been tagged with a hashtag oligo (HTO) prior to mixing, and that HTO can be used to identify which cells belong to which sample within a multiplexed library.
 The libraries available for download on the portal have not been separated by sample (i.e. demultiplexed), and therefore contain data from multiple samples.
+
 Note that multiplexed sample libraries are only available as `SingleCellExperiment` objects, and are not currently available as `AnnData` objects.
+If you prefer to work with `AnnData` objects, we recommend using the [`zellkonverter` package](https://bioconductor.org/packages/3.17/bioc/html/zellkonverter.html) to convert the `SingleCellExperiment` object to a HDF5 file containing an `AnnData` object.
 
 
 Libraries containing multiplexed samples can be initially processed using the same workflow described above including removal of [low quality cells](#quality-control), [normalization](#normalization), and [dimensionality reduction](#dimensionality-reduction).
@@ -323,6 +325,7 @@ sampleA_cells <- which(multiplexed_sce$vireo_sampleid == "sampleA")
 # create a new sce that only contains cells from sample A
 sampleA_sce <- multiplexed_sce[, sampleA_cells]
 ```
+
 
 Here are some additional resources that can be used for working with multiplexed samples (or those with cell hashing):
 - [Demultiplexing on HTO Abundance, Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.14/OSCA.advanced/droplet-processing.html#demultiplexing-on-hto-abundance)


### PR DESCRIPTION
Closes #164 

Here I continued with the progress I had started in #162 and modified the CITE-seq section to both refer to only the processed objects and add in AnnData objects. Generally, I follow the format I started in #162 to include an overview of the step or item (like filtering and QC) together but then show two separate commands for R and python. 

- Any duplicate commands for the processed and filtered objects have been condensed so that we only show how to work with the processed objects. This is what we did for the main section. 
- I condensed both accessing the ADT data and getting the raw/normalized counts into one code chunk for R and one for python. I'm curious what others think of this, but I think I like this better. I don't think we need a whole separate chunk for reading in a HDF5 file when we already show them how to do it for the main RNA data. 
- I also took a look at the multiplexed section and added a note that multiplexed libraries are only available as SCE objects. Let me know if I should add more there, but I think that note should be enough. 

Please let me know if there's any places you think I missed. 