### PR TITLE
Update docs to note we always use spliced and unspliced cDNA

### DIFF
--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -40,9 +40,7 @@ In contrast to Cell Ranger, `cr-like-em` keeps multi-mapped reads and invokes an
 
 #### Combining counts from spliced cDNA and intronic regions
 
-For single-cell samples, we only included reads aligning to spliced and ambiguous cDNA transcripts in the counts matrix.
-For single-nuclei samples, all counts for spliced cDNA and intronic regions were summed for each gene to return the total counts summarized by gene in the counts matrix.
-
+For single-cell and single-nuclei samples, the reads from spliced cDNA and intronic regions are combined by gene to produce a gene by cell counts matrix.
 After combining read counts, values are rounded to integer values.
 
 #### Filtering cells

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -18,6 +18,7 @@ sce <- readRDS("SCPCL000000_processed.rds")
 ### Expression counts
 
 The `counts` assay of the `SingleCellExperiment` object for single-cell and single-nuclei experiments (for all provided file types) contains the primary RNA-seq expression data as integer counts.
+The counts here include reads aligned to both spliced and unspliced cDNA (see the section on {ref}`Post Alevin-fry processing <processing_information:post alevin-fry processing`).
 The data is stored as a sparse matrix, and each column represents a cell or droplet, each row a gene.
 Column names are cell barcode sequences and row names are Ensembl gene IDs.
 The `counts` assay can be accessed with the following R code:
@@ -25,6 +26,8 @@ The `counts` assay can be accessed with the following R code:
 ```r
 count_matrix <- counts(sce)
 ```
+
+Additionally, the `spliced` assay contains a counts matrix that includes reads from spliced cDNA only.
 
 ### Cell metrics
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -18,7 +18,7 @@ sce <- readRDS("SCPCL000000_processed.rds")
 ### Expression counts
 
 The `counts` assay of the `SingleCellExperiment` object for single-cell and single-nuclei experiments (for all provided file types) contains the primary RNA-seq expression data as integer counts.
-The counts here include reads aligned to both spliced and unspliced cDNA (see the section on {ref}`Post Alevin-fry processing <processing_information:post alevin-fry processing`).
+The counts here include reads aligned to both spliced and unspliced cDNA (see the section on {ref}`Post Alevin-fry processing <processing_information:post alevin-fry processing>`).
 The data is stored as a sparse matrix, and each column represents a cell or droplet, each row a gene.
 Column names are cell barcode sequences and row names are Ensembl gene IDs.
 The `counts` assay can be accessed with the following R code:


### PR DESCRIPTION
Closes #142 
Note that this PR is getting merged into the new `documentation-improvements` branch that I made. This branch is protected and should be use for making all the pre-AnnData and pre-celltype changes. 

Here I updated the section on post processing alevin-fry to indicate that we always combine counts. I also added a sentence to the sce file contents to note that the `counts` matrix includes the counts from both spliced and unspliced cDNA and included a link to the processing information. 

I did include a sentence about the presence of the `spliced` assay in the object, but I'm unsure if we want to mention that or not... I'm curious about what others think. 