### PR TITLE
Add build.os argument to config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,15 +5,17 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  builder: html
   configuration: docs/conf.py
 
-formats: []
-
-# Optionally set the version of Python and requirements required to build your docs
+# Declare the Python requirements required to build your documentation
 python:
-   version: "3.7"
    install:
    - requirements: requirements.txt

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -5,13 +5,6 @@
 # Required
 version: 2
 
-# Set the OS, Python version and other tools you might need
-
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.7"
-
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
@@ -21,5 +14,6 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
+   version: "3.7"
    install:
    - requirements: requirements.txt

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -5,6 +5,13 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
@@ -14,6 +21,5 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: "3.7"
    install:
    - requirements: requirements.txt


### PR DESCRIPTION
Our builds are broken. I think this is why!

If this works and goes in, we'll need to file PRs to `development` and `documentation-improvements`.