### PR TITLE
Initialize CHANGELOG section

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -12,6 +12,7 @@ Bioinformatics
 cDNA
 cellhash
 cellhashing
+CHANGELOG
 confounders
 Danecek
 de

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,2 @@
+# CHANGELOG
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,3 +7,14 @@ You can find more information about how and when your download was prepared in t
 * The date your download was packaged (`Generated on: {date}`) is included at the top of the README in your download.
 * The version of the [`AlexsLemonade/scpca-nf`](https://github.com/alexsLemonade/scpca-nf) pipeline used to process data in your download is included in the `workflow_version` column of the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file in your download.
 For more information about `AlexsLemonade/scpca-nf` versions, please see [the releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases).
+
+<!-------------------------------------------------->
+<!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
+<!-------------------------------------------------->
+
+## {RELEASE DATE}
+
+* The README included in your download now contains the following:
+	* More information about how to cite the ScPCA Portal (see also: {ref}`How to Cite <citation:how to cite>`).
+	* The date your download was packaged (`Generated on: {date}`) at the top of the file.
+* The root directory of your download will contain the date you accessed and downloaded data from the ScPCA Portal when uncompressed.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,2 +1,9 @@
 # CHANGELOG
 
+As of November 2023, the `CHANGELOG` is a feature of our documentation we'll use to report and summarize changes to downloads from the ScPCA Portal.
+
+You can find more information about how and when your download was prepared in the following places:
+
+* The date that your download was packaged (`Generated on: {date}`) at the top of the README included in your download.
+* The version of the [`AlexsLemonade/scpca-nf`](https://github.com/alexsLemonade/scpca-nf) pipeline used to process data in your download in the `workflow_version` column of the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file included in your download.
+For more information about `AlexsLemonade/scpca-nf` versions, please see [the releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,6 @@ As of November 2023, the `CHANGELOG` is a feature of our documentation we'll use
 
 You can find more information about how and when your download was prepared in the following places:
 
-* The date that your download was packaged (`Generated on: {date}`) at the top of the README included in your download.
-* The version of the [`AlexsLemonade/scpca-nf`](https://github.com/alexsLemonade/scpca-nf) pipeline used to process data in your download in the `workflow_version` column of the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file included in your download.
+* The date your download was packaged (`Generated on: {date}`) is included at the top of the README in your download.
+* The version of the [`AlexsLemonade/scpca-nf`](https://github.com/alexsLemonade/scpca-nf) pipeline used to process data in your download is included in the `workflow_version` column of the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file in your download.
 For more information about `AlexsLemonade/scpca-nf` versions, please see [the releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -208,3 +208,8 @@ anndata_object["ADT"] = adt_anndata.to_df()
 It should be noted that in this conversion the `colData`, `rowData`, and metadata that are found in the original `SingleCellExperiment` objects will not be retained.
 If you would like to include this data, you could write out each table separately and load them manually in Python.
 Alternatively, you might be interested in this [reference from the authors of `scanpy`](https://theislab.github.io/scanpy-in-R/#converting-from-r-to-python) discussing a different approach to  conversion using Rmarkdown notebooks and the `reticulate` package to directly convert `SingleCellExperiment` object components to `AnnData` object components without writing files locally.
+
+## Why doesn't my existing code work on a new download from the Portal?
+
+Although we try to maintain backward compatibility, new features added to the ScPCA Portal may result in downloads that are no longer compatible with code written with older downloads from the ScPCA Portal in mind.
+Please see our {ref}`CHANGELOG <CHANGELOG:CHANGELOG>` for a summary of changes that impact downloads from the Portal.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,6 @@ download_files
 sce_file_contents
 getting_started
 faq
-CHANGELOG
 citation
+CHANGELOG
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,5 +11,6 @@ download_files
 sce_file_contents
 getting_started
 faq
+CHANGELOG
 citation
 ```


### PR DESCRIPTION
Closes #131. Here, I'm adding the initial version of the CHANGELOG. Per comments on that issue, this PR:

* Initializes the CHANGELOG file
* Adds intro text that covers where to find more information about downloads (i.e., workflow version and download generation date)
* Puts the CHANGELOG right after the FAQ section

~~Draft for now until I check the build and spell check. After that, I'll mark it as ready for review.~~ Ready for review!