### PR TITLE
Create release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -14,7 +14,7 @@ assignees: ''
 
 ### Preparing for the release
 - [ ] Does this release require an update to the CHANGELOG because there will be changes to downloadable files? If so, please create an issue tracking the CHANGELOG update and mark it as blocking this issue.
-- [ ] Are all other the issues planned for this release resolved? If any issues are unresolved, mark this issue as blocked by those on ZenHub.
+- [ ] Are all other issues planned for this release resolved? If any issues are unresolved, mark this issue as blocked by those on ZenHub.
 - [ ] Optional: If not all changes in `development` are ready to be released, create a feature branch off `main` and cherry pick commits from `development` to that feature branch.
 - [ ] File a PR from the `development` branch (or the new feature branch) to the `main` branch. This should include all of the changes that will be associated with the next release.
 

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Steps for a new release of `scpca-docs`
 <!-- Please include any notes about what will be included in this release -->
 <!-- e.g., you might want to mention if the release is related to a specific portal feature, like addition of AnnData objects -->
-<!-- Feel free to update the title of this issue to reflect the contents of the release -->
+<!-- Feel free to update the title of this issue to reflect the contents of the release (e.g., Prepare for scpca-docs release: AnnData) -->
 
 ### Preparing for the release
 

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,26 @@
+---
+name: Release checklist
+about: Prepare for a new release of scpca-docs
+title: Prepare for scpca-docs release
+labels: release
+assignees: ''
+
+---
+
+## Steps for a new release of `scpca-docs`
+<!-- Please include any notes about what will be included in this release -->
+<!-- e.g., you might want to mention if the release is related to a specific portal feature, like addition of AnnData objects -->
+<!-- Feel free to update the title of this issue to reflect the contents of the release -->
+
+### Preparing for the release
+
+- [ ] Are all of the issues planned for this release resolved? If there are any issues that are unresolved, mark this issue as blocked by those on ZenHub.
+- [ ] Optional: If not all changes in `development` are ready to be released, create a feature branch off `main` and cherry pick commits from `development` to that feature branch.
+- [ ] File a PR from the `development` branch (or the new feature branch) to the `main` branch. This should include all of the changes that will be associated with the next release.
+
+### Creating a release
+- [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.
+- [ ] In `Choose a tag`, use the current date as the release tag (`YYYY.MM.DD`), then click `Create a new tag: YYYY.MM.DD on publish`.
+- [ ] Write a description of the major changes in this release. You may want to start with the auto-generated release notes to save time.
+- [ ] Optional: If not all issues have been addressed, save a draft to return to later.
+- [ ] Publish the release!

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -10,11 +10,11 @@ assignees: ''
 ## Steps for a new release of `scpca-docs`
 <!-- Please include any notes about what will be included in this release -->
 <!-- e.g., you might want to mention if the release is related to a specific portal feature, like addition of AnnData objects -->
-<!-- Feel free to update the title of this issue to reflect the contents of the release (e.g., Prepare for scpca-docs release: AnnData) -->
+<!-- Update the title of this issue to reflect the contents of the release (e.g., Prepare for scpca-docs release: AnnData) -->
 
 ### Preparing for the release
-
-- [ ] Are all of the issues planned for this release resolved? If there are any issues that are unresolved, mark this issue as blocked by those on ZenHub.
+- [ ] Does this release require an update to the CHANGELOG because there will be changes to downloadable files? If so, please create an issue tracking the CHANGELOG update and mark it as blocking this issue.
+- [ ] Are all other the issues planned for this release resolved? If any issues are unresolved, mark this issue as blocked by those on ZenHub.
 - [ ] Optional: If not all changes in `development` are ready to be released, create a feature branch off `main` and cherry pick commits from `development` to that feature branch.
 - [ ] File a PR from the `development` branch (or the new feature branch) to the `main` branch. This should include all of the changes that will be associated with the next release.
 


### PR DESCRIPTION
Closes #175 

This PR adds a new issue template with a checklist for releases. I used a similar format to the [release template that we have in `scpca-nf`](https://github.com/AlexsLemonade/scpca-nf/blob/main/.github/ISSUE_TEMPLATE/release-checklist.md). I also tried to add some instructions to help if people are only releasing part of the updates that are present in `development`, especially because we are about to do that. Please check to make sure the instructions and additional comments are clear. 

One thing that I didn't do was add a version tag in the issue title. We have that for other release checklists, but here the tag is based on the day the docs get released. So instead, I added a note about updating the title to include the expected contents of the release. If others feel strongly about including the version tag in the title, then I can add that back in. 