### PR TITLE
Add PR template for publishing to `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -17,6 +17,7 @@ assignees: ''
 - [ ] Are all other issues planned for this release resolved? If any issues are unresolved, mark this issue as blocked by those on ZenHub.
 - [ ] Optional: If not all changes in `development` are ready to be released, create a feature branch off `main` and cherry pick commits from `development` to that feature branch.
 - [ ] File a PR from the `development` branch (or the new feature branch) to the `main` branch. This should include all of the changes that will be associated with the next release.
+  - [ ] If a CHANGELOG entry was required, add the date to the entry's header as part of this PR.
 
 ### Creating a release
 - [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.

--- a/.github/PULL_REQUEST_TEMPLATE/to-main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/to-main.md
@@ -1,0 +1,17 @@
+## Purpose
+
+<!-- Describe the big picture of your changes -->
+
+### Issue addressed
+
+<!-- What issue does this address? -->
+<!-- This will often be a release issue. -->
+
+
+## Checklist for publishing to `main`
+
+<!-- Use this when releasing features -->
+
+- [ ] This branch contains all commits/content ready to be released.
+- [ ] The most recent CHANGELOG entry includes a date.
+If this release required a CHANGELOG entry, it should be today's date.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-⚠️ **Is this pull request targeting `main`?** Use this template: <a href="?expand=1&template=to-main.md"> PR to `main` </a> ⚠️
+⚠️ **Is this pull request targeting `main`?** Use this template: <a href="?expand=1&template=to-main.md"> PR to `main` </a> ⚠️ _Delete this otherwise!_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+⚠️ **Is this pull request targeting `main`?** Use this template: <a href="?expand=1&template=to-main.md"> PR to `main` </a> ⚠️


### PR DESCRIPTION
Here I'm making three changes:

1. Adding a checkbox to the release issue template to remind people to update the date of the CHANGELOG entry as applicable
2. Adding a PR template for merging to main that includes a checklist geared towards publishing a release
3. Adding a "main" PR template that just tells people to use the other template if they're targeting `main`.