### PR TITLE
Add CHANGELOG entry for docs improvements epic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,3 +7,14 @@ You can find more information about how and when your download was prepared in t
 * The date your download was packaged (`Generated on: {date}`) is included at the top of the README in your download.
 * The version of the [`AlexsLemonade/scpca-nf`](https://github.com/alexsLemonade/scpca-nf) pipeline used to process data in your download is included in the `workflow_version` column of the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file in your download.
 For more information about `AlexsLemonade/scpca-nf` versions, please see [the releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases).
+
+<!-------------------------------------------------->
+<!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
+<!-------------------------------------------------->
+
+## {RELEASE DATE}
+
+* The README included in your download now contains the following:
+	* More information about how to cite the ScPCA Portal (see also: {ref}`How to Cite <citation:how to cite>`).
+	* The date your download was packaged (`Generated on: {date}`) at the top of the file.
+* The root directory of your download will contain the date you accessed and downloaded data from the ScPCA Portal when uncompressed.


### PR DESCRIPTION
⚠️ _Stacked on #184_

Closes #187. I am adding a CHANGELOG entry that covers the following updates to downloads associated with https://github.com/AlexsLemonade/ScPCA-admin/issues/683:

* Access date in root directory of downloads
* README updates:
  * Generated on date
  * Citation section 

