### PR TITLE
Link to scpca-docs releases in release-checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -20,7 +20,7 @@ assignees: ''
   - [ ] If a CHANGELOG entry was required, add the date to the entry's header as part of this PR.
 
 ### Creating a release
-- [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.
+- [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-docs/releases), choose `Draft a new release`.
 - [ ] In `Choose a tag`, use the current date as the release tag (`YYYY.MM.DD`), then click `Create a new tag: YYYY.MM.DD on publish`.
 - [ ] Write a description of the major changes in this release. You may want to start with the auto-generated release notes to save time.
 - [ ] Optional: If not all issues have been addressed, save a draft to return to later.


### PR DESCRIPTION
## Purpose

<!-- Describe the big picture of your changes -->

I noticed that the release page link was to `scpca-nf` when I cut the release from the `2023.11.10` tag this morning. This updates the release issue template to point to this repo's releases page. 

### Issue addressed

<!-- What issue does this address? -->
<!-- This will often be a release issue. -->

N/A
