### PR TITLE
Brackets to parentheses

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -260,7 +260,7 @@ Note that submitter-provided annotations are also present in unfiltered and filt
 
 #### `SingleR` annotations
 
-`SingleR` annotation uses a reference dataset from the [`celldex` package](https://bioconductor.org/packages/release/data/experiment/html/celldex.html) [[Aran _et al._ (2019)](https://doi.org/10.1038/s41590-018-0276-y)].
+`SingleR` annotation uses a reference dataset from the [`celldex` package](https://bioconductor.org/packages/release/data/experiment/html/celldex.html) ([Aran _et al._ (2019)](https://doi.org/10.1038/s41590-018-0276-y)).
 
 
 To access automated `SingleR` annotations as cell type names and/or ontology terms in the process `SingleCellExperiment` object, use the following command(s):
@@ -294,7 +294,7 @@ metadata(processed_sce)$singler_results
 
 #### `CellAssign` annotations
 
-`CellAssign` annotation uses a reference set of marker genes from the [`PanglaoDB` database](https://panglaodb.se/) [[Oscar Franzén _et al._ (2019)](https://doi.org/10.1093/database/baz046)], as compiled by the Data Lab for a given tissue group.
+`CellAssign` annotation uses a reference set of marker genes from the [`PanglaoDB` database](https://panglaodb.se/) ([Oscar Franzén _et al._ (2019)](https://doi.org/10.1093/database/baz046)), as compiled by the Data Lab for a given tissue group.
 
 To access automated `CellAssign` annotations in the `SingleCellExperiment`, use the following command:
 


### PR DESCRIPTION
As pointed out here, https://github.com/AlexsLemonade/scpca-docs/issues/165#issuecomment-1813235397, some link parentheticals are in brackets, not parentheses. 

> It seems pretty reasonable. I will pick a nit, though – some of the publication references in the cell annotation section use `[]` instead of `()` and I don't know why.


This PR fixes those spots! Did I miss any, or notice anything else while we're here?