### PR TITLE
Add cell type changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,8 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 
 ## PLACEHOLDER FOR CELL TYPING RELEASE DATE
 
-* Downloads will now contain cell type annotations as inferred with [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html) and [`CellAssign`](https://github.com/Irrationone/cellassign).
+* Cell type annotations are now included in each download. 
+Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html) and [`CellAssign`](https://github.com/Irrationone/cellassign).
   * You can find more information about the cell type annotation procedure in the {ref}`the section describing cell type annotation procedures on the Processing Information page<processing_information:cell type annotation>`, as well as more information about available cell type annotation information in downloadable files from {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,8 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 
 * Cell type annotations are now included in each download. 
 Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html) and [`CellAssign`](https://github.com/Irrationone/cellassign).
-  * You can find more information about the cell type annotation procedure in the {ref}`the section describing cell type annotation procedures on the Processing Information page<processing_information:cell type annotation>`, as well as more information about available cell type annotation information in downloadable files from {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
+  * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`. 
+  For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,14 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+
+## PLACEHOLDER FOR CELL TYPING RELEASE DATE
+
+* Downloads will now contain cell type annotations as inferred with [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html) and [`CellAssign`](https://github.com/Irrationone/cellassign).
+  * You can find more information about the cell type annotation procedure in the {ref}`the section describing cell type annotation procedures on the Processing Information page<processing_information:cell type annotation>`, as well as more information about available cell type annotation information in downloadable files from {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
+* Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
+
+
 ## PLACEHOLDER FOR RELEASE DATE
 
 * Downloads for most projects are now available in [`AnnData`](https://anndata.readthedocs.io/en/latest/index.html) format as HDF5 files.


### PR DESCRIPTION
Closes #209 

Here, I've added text for a cell type annotation changelog. I decided to leave out some of the details that I had noted in #209, instead favoring linking to the relevant docs sections. As a consequence the changelog is actually pretty short. What do we think about this decision?

Note that I'm opening this as a Draft because we _absolutely do not want to merge anytime (super) soon_..!