### PR TITLE
Add documentation in processing_information for merged objects

### DIFF
--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -175,3 +175,21 @@ The [decoy-aware reference transcriptome](https://salmon.readthedocs.io/en/lates
 
 A benefit of using `salmon` is the ability to incorporate RNA-seq specific technical biases and correct counts accordingly.
 We chose to enable the [`--seqBias`](https://salmon.readthedocs.io/en/latest/salmon.html#seqbias) and [`--gcBias`](https://salmon.readthedocs.io/en/latest/salmon.html#gcbias) flags, to correct for sequence-specific biases due to random hexamer primer and fragment-level GC biases, respectively.
+
+## Merged objects
+
+In addition to downloadable objects containing a single library, we also offer a merged object to download for each project, representing all libraries contained in a single file.
+This section describes how these merged objects were prepared.
+
+Merged objects were created from the processed `SingleCellExperiment` objects for each ScPCA project.
+
+If at least one library in the given project contained ADT data from CITE-seq experiments, the associated ADT "alternative experiment" was also merged.
+Any libraries in the given project which did not contain ADT data will contain `NA` values in the merged `counts` and `logcounts` matrices.
+
+By contrast, cell hashing alternative experiments were not merged.
+For any projects with cell hash data, only the associated RNA data was merged in the final object.
+
+After merging, new principal component analysis (PCA) coordinates and UMAP embedding were calculated so that each library in the merged object is equally weighted.
+For this, the top 2000 high-variance genes (HVGs) were calculated by modeling variance separately for each library in the merged object.
+These HVGs were used as input to the PCA, which was calcualted using the [`batchelor::multiBatchPCA` function](https://rdrr.io/bioc/batchelor/man/multiBatchPCA.html) and specifying libraries as batches, and the top 50 principal components were selected.
+These new principal components were used to calculate the new UMAP embeddings.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -182,7 +182,7 @@ In addition to providing separate objects for each library, we also offer an opt
 This merged object contains the gene expression data for all libraries from a single project in a single file.
 This section describes how these merged objects were prepared.
 
-Following post-processing of each `SingleCellExperiment` (see XXX section above on post-processing) object, all objects belonging to a single ScPCA project were merged together. 
+Following post-processing of each `SingleCellExperiment` ([see the section above on post-processing](#processed-gene-expression-data)) object, all objects belonging to a single ScPCA project were merged together.
 **These merged objects were not batch-corrected; they do not represent integrated objects.**
 
 If at least one library in the given project contained ADT data from CITE-seq experiments, the associated ADT "alternative experiment" was also merged.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -178,19 +178,20 @@ We chose to enable the [`--seqBias`](https://salmon.readthedocs.io/en/latest/sal
 
 ## Merged objects
 
-In addition to downloadable objects containing a single library, we also offer a merged object to download for each project, representing all libraries contained in a single file.
+In addition to providing separate objects for each library, we also offer an option to download all files for a project as a single merged object.
+This merged object contains the gene expression data for all libraries from a single project in a single file.
 This section describes how these merged objects were prepared.
 
-Merged objects were created from the processed `SingleCellExperiment` objects for each ScPCA project.
+Following post-processing of each `SingleCellExperiment` (see XXX section above on post-processing) object, all objects belonging to a single ScPCA project were merged together. 
 **These merged objects were not batch-corrected; they do not represent integrated objects.**
 
 If at least one library in the given project contained ADT data from CITE-seq experiments, the associated ADT "alternative experiment" was also merged.
-Any libraries in the given project which did not contain ADT data will contain `NA` values in the merged `counts` and `logcounts` matrices.
+Any libraries in the given project which did not contain ADT data will contain `NA` values in the merged gene by counts matrices.
 
 By contrast, cell hashing alternative experiments were not merged.
 For any projects with cell hash data, only the associated RNA data was merged in the final object.
 
-After merging, new principal component analysis (PCA) coordinates and UMAP embedding were calculated so that each library in the merged object is equally weighted.
+After merging, new principal component analysis (PCA) coordinates and UMAP embeddings were calculated so that each library in the merged object is equally weighted.
 For this, the top 2000 high-variance genes (HVGs) were calculated by modeling variance separately for each library in the merged object.
 These HVGs were used as input to the PCA, which was calculated using the [`batchelor::multiBatchPCA` function](https://rdrr.io/bioc/batchelor/man/multiBatchPCA.html) and specifying libraries as batches, and the top 50 principal components were selected.
 These new principal components were used to calculate the new UMAP embeddings.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -182,6 +182,7 @@ In addition to downloadable objects containing a single library, we also offer a
 This section describes how these merged objects were prepared.
 
 Merged objects were created from the processed `SingleCellExperiment` objects for each ScPCA project.
+**These merged objects were not batch-corrected; they do not represent integrated objects.**
 
 If at least one library in the given project contained ADT data from CITE-seq experiments, the associated ADT "alternative experiment" was also merged.
 Any libraries in the given project which did not contain ADT data will contain `NA` values in the merged `counts` and `logcounts` matrices.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -194,4 +194,4 @@ For any projects with cell hash data, only the associated RNA data was merged in
 After merging, new principal component analysis (PCA) coordinates and UMAP embeddings were calculated so that each library in the merged object is equally weighted.
 For this, the top 2000 high-variance genes (HVGs) were calculated by modeling variance separately for each library in the merged object.
 These HVGs were used as input to the PCA, which was calculated using the [`batchelor::multiBatchPCA` function](https://rdrr.io/bioc/batchelor/man/multiBatchPCA.html) and specifying libraries as batches, and the top 50 principal components were selected.
-These new principal components were used to calculate the new UMAP embeddings.
+These new principal components were used to calculate the new UMAP embeddings found in the merged object.

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -192,5 +192,5 @@ For any projects with cell hash data, only the associated RNA data was merged in
 
 After merging, new principal component analysis (PCA) coordinates and UMAP embedding were calculated so that each library in the merged object is equally weighted.
 For this, the top 2000 high-variance genes (HVGs) were calculated by modeling variance separately for each library in the merged object.
-These HVGs were used as input to the PCA, which was calcualted using the [`batchelor::multiBatchPCA` function](https://rdrr.io/bioc/batchelor/man/multiBatchPCA.html) and specifying libraries as batches, and the top 50 principal components were selected.
+These HVGs were used as input to the PCA, which was calculated using the [`batchelor::multiBatchPCA` function](https://rdrr.io/bioc/batchelor/man/multiBatchPCA.html) and specifying libraries as batches, and the top 50 principal components were selected.
 These new principal components were used to calculate the new UMAP embeddings.


### PR DESCRIPTION
Closes #215 

This PR adds a very short section about merged processing. I don't think much more background is needed to review this PR! I'm honestly not sure if I've struck the right balance of level of detail; I did open with a bit more context than would be expected in this processing information docs, but it seemed like maybe a good idea because this section describes fundamentally different objects from the rest of the page? 

Let me know what you think and where I can expand or where I can reduce!