### PR TITLE
Document xenograft and cell line samples 

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -94,5 +94,6 @@ UMI
 UMIs
 uncompress
 unspliced
+xenograft
 xenografts
 Zhang

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -218,7 +218,8 @@ This report evaluates cell annotations results as follows:
 - If multiple annotations are present, the report compares different annotations to one another.
 Strong agreement between different annotation methods is a qualitative indicator of robustness.
 
-To determine which methods were used for cell type annotations, use the following command on the processed `SingleCellExperiment` object:
+To determine which methods were used for cell type annotations, use the following command on the processed `SingleCellExperiment` object.
+If this returns `NULL`, then no cell type annotation was performed for the given library.
 
 ```r
 # show vector of available celltypes
@@ -226,7 +227,8 @@ To determine which methods were used for cell type annotations, use the followin
 metadata(processed_sce)$celltype_methods
 ```
 
-Or, on the processed `AnnData` object:
+Or, use the following command on the processed `AnnData` object.
+If this returns an empty list, then no cell type annotation was performed for the given library.
 
 ```python
 # show list of available celltypes

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -85,6 +85,7 @@ During annotation, we additionally include an `"other"` cell type that does not 
 As a consequence, cells which `CellAssign` cannot confidently annotate from the full marker gene list are labeled as `"other"`.
 
 Cell type annotation is not performed for cell line samples.
+For information on how to determine if a given sample was derived from a cell line, refer to section(s) describing {ref}`SingleCellExperiment file contents <sce_file_contents:singlecellexperiment sample metadata>` and/or {ref}`AnnData file contents <sce_file_contents:anndata cell metrics>`.
 
 **Note:** For some libraries, cell type annotations were provided from the group that submitted the original data.
 In these cases, the cell type annotations obtained from the submitter will be present in addition to cell type annotation performed with `SingleR` and `CellAssign`.
@@ -146,7 +147,7 @@ For multiplex libraries where bulk RNA-seq data is available for the individual 
 - Cell genotypes were used to call sample of origin with [`vireo`](https://vireosnp.readthedocs.io) ([Huang _et al._ 2019](https://doi.org/10.1186/s13059-019-1865-2))
 
 The genetic demultiplexing calls are reported alongside HTO demultiplexing results for each library, but we again do not separate the individual samples.
-For information on where the demultiplexing calls can be found, see {ref}`the section on demultiplexing results in the  SingleCellExperiment file contents. <sce_file_contents:demultiplexing results>`
+For information on where the demultiplexing calls can be found, see {ref}`the section on demultiplexing results in the SingleCellExperiment file contents. <sce_file_contents:demultiplexing results>`
 
 
 ## Spatial transcriptomics

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -84,6 +84,8 @@ We combine these marker genes with all "immune cell" `PanglaoDB` marker genes to
 During annotation, we additionally include an `"other"` cell type that does not express any of these marker genes.
 As a consequence, cells which `CellAssign` cannot confidently annotate from the full marker gene list are labeled as `"other"`.
 
+Cell type annotation is not performed for cell line samples.
+
 **Note:** For some libraries, cell type annotations were provided from the group that submitted the original data.
 In these cases, the cell type annotations obtained from the submitter will be present in addition to cell type annotation performed with `SingleR` and `CellAssign`.
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -377,7 +377,7 @@ The `AnnData` object also includes the following additional cell-level metadata 
 | `disease_timing`  | At what stage of disease the sample was obtained, either diagnosis or recurrence |
 | `organism`         | The organism the sample was obtained from (e.g., `Homo_sapiens`) |
 | `is_xenograft`    | Whether the sample is a patient-derived xenograft |
-| `is_cell_line`    | Whether the sample derived from a cell line |
+| `is_cell_line`    | Whether the sample was derived from a cell line |
 | `development_stage_ontology_term_id` | [`HsapDv` ontology](http://obofoundry.org/ontology/hsapdv.html) term indicating developmental stage. If unavailable, `unknown` is used  |
 | `sex_ontology_term_id` | [`PATO`](http://obofoundry.org/ontology/pato.html) term referring to the sex of the sample. If unavailable, `unknown` is used |
 | `organism_ontology_id` | [NCBI taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy) term for organism, e.g. [`NCBITaxon:9606`](http://purl.obolibrary.org/obo/NCBITaxon_9606) |

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -168,6 +168,8 @@ The following columns are included in the sample metadata data frame for all lib
 | `tissue_location` | Where in the body the tumor sample was located                 |
 | `disease_timing`  | At what stage of disease the sample was obtained, either diagnosis or recurrence |
 | `organism`         | The organism the sample was obtained from (e.g., `Homo_sapiens`) |
+| `is_xenograft`    | Whether the sample is a patient-derived xenograft |
+| `is_cell_line`    | Whether the sample derived from a cell line |
 | `development_stage_ontology_term_id` | [`HsapDv` ontology](http://obofoundry.org/ontology/hsapdv.html) term indicating developmental stage. If unavailable, `unknown` is used  |
 | `sex_ontology_term_id` | [`PATO`](http://obofoundry.org/ontology/pato.html) term referring to the sex of the sample. If unavailable, `unknown` is used |
 | `organism_ontology_id` | [NCBI taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy) term for organism, e.g. [`NCBITaxon:9606`](http://purl.obolibrary.org/obo/NCBITaxon_9606) |
@@ -374,6 +376,8 @@ The `AnnData` object also includes the following additional cell-level metadata 
 | `tissue_location` | Where in the body the tumor sample was located                 |
 | `disease_timing`  | At what stage of disease the sample was obtained, either diagnosis or recurrence |
 | `organism`         | The organism the sample was obtained from (e.g., `Homo_sapiens`) |
+| `is_xenograft`    | Whether the sample is a patient-derived xenograft |
+| `is_cell_line`    | Whether the sample derived from a cell line |
 | `development_stage_ontology_term_id` | [`HsapDv` ontology](http://obofoundry.org/ontology/hsapdv.html) term indicating developmental stage. If unavailable, `unknown` is used  |
 | `sex_ontology_term_id` | [`PATO`](http://obofoundry.org/ontology/pato.html) term referring to the sex of the sample. If unavailable, `unknown` is used |
 | `organism_ontology_id` | [NCBI taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy) term for organism, e.g. [`NCBITaxon:9606`](http://purl.obolibrary.org/obo/NCBITaxon_9606) |

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -169,7 +169,7 @@ The following columns are included in the sample metadata data frame for all lib
 | `disease_timing`  | At what stage of disease the sample was obtained, either diagnosis or recurrence |
 | `organism`         | The organism the sample was obtained from (e.g., `Homo_sapiens`) |
 | `is_xenograft`    | Whether the sample is a patient-derived xenograft |
-| `is_cell_line`    | Whether the sample derived from a cell line |
+| `is_cell_line`    | Whether the sample was derived from a cell line |
 | `development_stage_ontology_term_id` | [`HsapDv` ontology](http://obofoundry.org/ontology/hsapdv.html) term indicating developmental stage. If unavailable, `unknown` is used  |
 | `sex_ontology_term_id` | [`PATO`](http://obofoundry.org/ontology/pato.html) term referring to the sex of the sample. If unavailable, `unknown` is used |
 | `organism_ontology_id` | [NCBI taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy) term for organism, e.g. [`NCBITaxon:9606`](http://purl.obolibrary.org/obo/NCBITaxon_9606) |


### PR DESCRIPTION
Closes #222
Closes #227 

This PR adds some documentation for xenograft and cell lines:

- In `processing_information.md`, I added text that there is no cell typing for cell lines, and I also pointed users to where they can figure out if their sample is a cell line....
- ....in table lines which I added into `sce_file_contents.md` for both SCE and AnnData objects
- I also added some little blurbs in `docs/getting_started.md` that if cell type methods are empty, there are no cell type methods.

Let me know if there are other spots I didn't think of that could use some additional docs, and/or any wording feedback!