### PR TITLE
Add community contributed data to changelog

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -95,5 +95,6 @@ UMI
 UMIs
 uncompress
 unspliced
+xenograft
 xenografts
 Zhang

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,13 +13,15 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-------------------------------------------------->
 
 
-## PLACEHOLDER FOR CELL TYPING RELEASE DATE
+## PLACEHOLDER FOR CELL TYPING/COMMUNITY CONTRIBUTIONS RELEASE DATE
 
 * Cell type annotations are now included in each download.
 Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html) and [`CellAssign`](https://github.com/Irrationone/cellassign).
   * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`.
   For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
+* This release additionally includes community-contributed datasets.
+Like all other projects in the ScPCA Portal, all community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline.
 
 
 ## PLACEHOLDER FOR RELEASE DATE

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,8 +20,10 @@ Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/re
   * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`.
   For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
+* Sample metadata will not includes two additional pieces of information which can be used to filter datasets: Whether the given sample is a patient-derived xenograft, and whether the sample is derived from a cell line.
 * This release additionally includes new projects containing community-contributed datasets.
 Like all other projects in the ScPCA Portal, all community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline.
+Community-contributed projects will be indicated with badge on their project page.
 
 
 ## PLACEHOLDER FOR RELEASE DATE

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,8 @@ Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/re
 * Sample metadata will now include two additional pieces of information which can be used to filter datasets: Whether the given sample is a patient-derived xenograft, and whether the sample is derived from a cell line.
 * This release additionally includes new projects containing community-contributed datasets.
 Like all other projects in the ScPCA Portal, all community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline.
-Community-contributed projects will be indicated with badge on their project page.
+  * Community-contributed projects will be indicated with badge on their project page.
+  * Please refer to the [contributions page](https://scpca.alexslemonade.org/contribute) for more information about community contributions.
 
 
 ## PLACEHOLDER FOR RELEASE DATE

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/re
   * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`.
   For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
-* This release additionally includes community-contributed datasets.
+* This release additionally includes new projects containing community-contributed datasets.
 Like all other projects in the ScPCA Portal, all community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline.
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,10 +21,9 @@ Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/re
   For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
 * Sample metadata will now include two additional pieces of information which can be used to filter datasets: Whether the given sample is a patient-derived xenograft, and whether the sample is derived from a cell line.
-* This release additionally includes new projects containing community-contributed datasets.
-Like all other projects in the ScPCA Portal, all community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline.
-  * Community-contributed projects will be indicated with badge on their project page.
-  * Please refer to the [contributions page](https://scpca.alexslemonade.org/contribute) for more information about community contributions.
+* This release additionally includes community-contributed projects.
+Community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline. 
+Please refer to the [contributions page](https://scpca.alexslemonade.org/contribute) for more information about community contributions.
 
 
 ## PLACEHOLDER FOR RELEASE DATE

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/re
   * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`.
   For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
-* Sample metadata will not includes two additional pieces of information which can be used to filter datasets: Whether the given sample is a patient-derived xenograft, and whether the sample is derived from a cell line.
+* Sample metadata will now include two additional pieces of information which can be used to filter datasets: Whether the given sample is a patient-derived xenograft, and whether the sample is derived from a cell line.
 * This release additionally includes new projects containing community-contributed datasets.
 Like all other projects in the ScPCA Portal, all community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline.
 Community-contributed projects will be indicated with badge on their project page.


### PR DESCRIPTION
**Stacked on the cell type release PR**

This PR adds a bullet to the cell type `CHANGELOG` section to indicate that community-contributed datasets are also available. I wasn't exactly sure the right level of detail to include here, let me know what you think. Too much? Too little? Wrong details entirely?

We could also link the contributing page (https://scpca.alexslemonade.org/contribute) to give readers more context?