### PR TITLE
Add section to FAQ about projects without merged objects

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -177,3 +177,17 @@ The samples have simply been merged into a single file - _they have not been int
 You may prefer to download this merged object instead of individual sample files to facilitate downstream analyses that consider multiple samples at once, such as differential expression analysis, integrating multiple samples, or jointly clustering multiple samples.
 
 Please refer to {ref}`the getting started with a merged object section<getting_started:working with a merged scpca object` for more details on working with merged objects.
+
+
+## Which projects can I download as a merged objects?
+
+Most projects in the ScPCA Portal are available for download as a merged object, with a few exceptions.
+
+First, merged object downloads are not provided for projects comprised of spatial transcriptomics.
+As described in {ref}`the spatial transcriptomics processing section<processing_information:spatial transcriptomics`, no post-processing is performed on these libraries after running Space Ranger.
+Therefore, merging samples into a single object is beyond the scope of the ScPCA pipeline.
+
+Second, although projects with multiplexing will have associated merged objects, those merged objects will not contain the hashtag oligonucleotide (HTO) results; they will only contain gene expression results.
+This is because, although the ScPCA pipeline {ref}`reports demultiplexing results<processing_information:HTO demultiplexing>`, the libraries do not actually undergo demultiplexing itself.
+As there is no guarantee that a unique HTO was used for each sample in a given project, it would not necessarily be possible to determine which HTO corresponds to which sample in a merged object.
+Therefore, we do not merge the cellhash components of multiplexed projects.

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -331,7 +331,7 @@ In addition, the following columns in the `colData` slot `DataFrame` contain dem
 | `vireo_sampleid`            | Most likely sample as called by `vireo` (genetic demultiplexing) |
 
 
-Unlike in {ref}`individual SingleCellExperiment objects<sce_file_contents:additional SingleCellExperiment components for multiplexed libraries`, hashtag oligo (HTO) quantification will not be included in the merged `SingleCellExperiment` as an alternative experiment, as described in the <TODO: FORTHCOMING FAQ ABOUT WHY IT'S NOT THERE>.
+Unlike in {ref}`individual SingleCellExperiment objects<sce_file_contents:additional SingleCellExperiment components for multiplexed libraries`, hashtag oligo (HTO) quantification will not be included in the merged `SingleCellExperiment` as an alternative experiment, as described in the ref`{frequently asked questions:faq:which projects can I download as a merged objects?}`.
 
 
 ## Components of an AnnData merged object


### PR DESCRIPTION
Closes #221

In this PR and very well-named branch, I added a section to the FAQ about circumstances where there is no merged object. I think this could be two sections instead of one, but since each would be so small I started off by collapsing into one section. 

Please let me know what you think of the section title, whether it should be 1 or 2 sections, and whether I've hit all the right points or should expand/reduce anywhere!