### PR TITLE
Fix uns/obs typo

### DIFF
--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -484,7 +484,7 @@ In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`]
 | `high.controls` | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present |
 | `ambient.scale` | The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present                         |
 | `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present  |
-| `discard`       | Indicates whether the cell should be discarded based on QC statistics                                                         |
+| `discard`       | Indicates whether the cell should be discarded based on QC statistics. The `TRUE` and `FALSE` values in this column correspond, respectively, to values `"Discard"` and `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column                                                         |
 
 
 Metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the `.var` slot within the `AnnData` object:

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -470,7 +470,7 @@ Each column corresponds to a cell or droplet (in the same order as the main `Ann
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
 As with the RNA `AnnData` objects, in processed objects _only_ (`_processed_adt.hdf5`), the data matrix `X` contains the normalized ADT counts and the primary data can be found in `raw.X`.
-Note that only cells which are denoted as `"Keep"` in  the `adata_obj.uns["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
+Note that only cells which are denoted as `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
 However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances.
 In such cases the `AnnData` object will not contain a normalized expression matrix, but the primary data will still be stored in `X`.
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -470,20 +470,21 @@ Each column corresponds to a cell or droplet (in the same order as the main `Ann
 Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
 
 As with the RNA `AnnData` objects, in processed objects _only_ (`_processed_adt.hdf5`), the data matrix `X` contains the normalized ADT counts and the primary data can be found in `raw.X`.
-Note that only cells which are denoted as `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
+Only cells which are denoted as `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
+Note that this filtering information is also available in the `discard` column of the object's `.obs` slot, as described in the table below.
 However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances.
 In such cases the `AnnData` object will not contain a normalized expression matrix, but the primary data will still be stored in `X`.
 
 In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `obs` slot of each ADT-specific `AnnData` object.
 
-| Column name                | Contents                                          |
-| -------------------------- | ------------------------------------------------- |
-| `zero.ambient`   | Indicates whether the cell has zero ambient contamination   |
-| `sum.controls` |  The sum of counts for all control features. Only present if negative/isotype control ADTs are present |
-| `high.controls`  | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present |
-| `ambient.scale` |  The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present |
-| `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present |
-| `discard`  | Indicates whether the cell should be discarded based on QC statistics |
+| Column name     | Contents                                                                                                                      |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `zero.ambient`  | Indicates whether the cell has zero ambient contamination                                                                     |
+| `sum.controls`  | The sum of counts for all control features. Only present if negative/isotype control ADTs are present                         |
+| `high.controls` | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present |
+| `ambient.scale` | The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present                         |
+| `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present  |
+| `discard`       | Indicates whether the cell should be discarded based on QC statistics                                                         |
 
 
 Metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the `.var` slot within the `AnnData` object:


### PR DESCRIPTION
I found an important typo to fix! This should have said `.obs`, not `.uns`.

Once this goes in, I'll cherry-pick into the 2 release draft PRs.