### PR TITLE
Complete merged anndata docs

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -15,7 +15,7 @@ jobs:
   spell-check:
     runs-on: ubuntu-latest
     container:
-      image: rocker/tidyverse:4.0.3
+      image: rocker/tidyverse:4.3.2
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,10 +15,10 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 
 ## PLACEHOLDER FOR CELL TYPING RELEASE DATE
 
-* Cell type annotations are now included in each download. 
+* Cell type annotations are now included in each download.
 Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html) and [`CellAssign`](https://github.com/Irrationone/cellassign).
-  * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`. 
-  For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<processing_information:components of a singlecellexperiment object>`.
+  * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`.
+  For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<sce_file_contents:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -176,7 +176,7 @@ The samples have simply been merged into a single file - _they have not been int
 
 You may prefer to download this merged object instead of individual sample files to facilitate downstream analyses that consider multiple samples at once, such as differential expression analysis, integrating multiple samples, or jointly clustering multiple samples.
 
-Please refer to {ref}`the getting started with a merged object section<getting_started:working with a merged scpca object` for more details on working with merged objects.
+Please refer to {ref}`the getting started with a merged object section<getting_started:Working with a Merged ScPCA object>` for more details on working with merged objects.
 
 
 ## Which projects can I download as a merged objects?
@@ -184,7 +184,7 @@ Please refer to {ref}`the getting started with a merged object section<getting_s
 Most projects in the ScPCA Portal are available for download as a merged object, with a few exceptions.
 
 First, merged object downloads are not provided for projects comprised of spatial transcriptomics.
-As described in {ref}`the spatial transcriptomics processing section<processing_information:spatial transcriptomics`, no post-processing is performed on these libraries after running Space Ranger.
+As described in {ref}`the spatial transcriptomics processing section<processing_information:spatial transcriptomics>`, no post-processing is performed on these libraries after running Space Ranger.
 Therefore, merging samples into a single object is beyond the scope of the ScPCA pipeline.
 
 Second, although projects with multiplexing will have associated merged objects, those merged objects will not contain the hashtag oligonucleotide (HTO) results; they will only contain gene expression results.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -103,7 +103,7 @@ Here we provide more resources on understanding normalization in single-cell RNA
 The processed `SingleCellExperiment` objects already have undergone additional quality control steps to remove low quality cells.
 Low quality cells include those with a higher percentage of reads from mitochondrial genes (i.e., those that are damaged or dying) and those with a lower number of total reads and unique genes identified (i.e., those with inefficient reverse transcription or PCR amplification).
 
-All processed objects include [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) results found in the {ref}`colData() of the SingleCellExperiment object<sce_file_contents:Singlecellexperiment cell metrics>` or the {ref}`.obs slot of the AnnData object<sce_file_contents:Anndata cell metrics`.
+All processed objects include [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) results found in the {ref}`colData() of the SingleCellExperiment object<sce_file_contents:Singlecellexperiment cell metrics>` or the {ref}`.obs slot of the AnnData object<sce_file_contents:Anndata cell metrics>`.
 `miQC` jointly models the proportion of mitochondrial reads and the number of unique genes detected in each cell to calculate the probability of a cell being compromised (i.e., dead or damaged).
 High-quality cells are those with a low probability of being being compromised (< 0.75) or sufficiently low mitochondrial content.
 
@@ -332,7 +332,7 @@ See these resources for more information on automated cell type annotation:
 ## Working with a merged ScPCA object
 
 Merged ScPCA objects contain all information found in `processed` objects for all individual libraries that comprise a given ScPCA project.
-For more information on how these objects were prepared, see {ref}`the section on merged object preparation<processing_information:merged objects`.
+For more information on how these objects were prepared, see {ref}`the section on merged object preparation<processing_information:merged objects>`.
 **Please be aware that data in merged objects has not been integrated/batch-corrected.**
 
 To work with a merged object, you will first have to read it in.

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -412,3 +412,16 @@ The following items are available in the `.uns` slot:
 | `merged_highly_variable_genes` | A list of highly variable genes used for performing dimensionality reduction on the merged object, determined using `scran::modelGeneVar`, specifying each library as a separate block, and `scran::getTopHVGs` |
 
 Additional experiment metadata is available in the {ref}`metadata TSV file included in the ScPCA Portal download folder <download_files:Metadata>`.
+
+### AnnData dimensionality reduction results
+
+The merged `AnnData` object contains a slot `.obsm` with both principal component analysis (`X_PCA`) and UMAP (`X_UMAP`) results.
+
+For information on how PCA and UMAP results were calculated see the {ref}`section on processed gene expression data <processing_information:Processed gene expression data>`.
+
+The following command can be used to access the PCA and UMAP results:
+
+```python
+merged_adata_object.obsm["X_PCA"] # pca results
+merged_adata_object.obsm["X_UMAP"] # umap results
+```

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -434,7 +434,7 @@ ADT data from CITE-seq experiments, when present, is available as a separate `An
 Merged `AnnData` objects contain two data matrices, each containing CITE-seq expression data for all libraries in a given ScPCA project combined into a single matrix.
 The data matrix `raw.X` of the merged `AnnData` object contains the CITE-seq expression data as primary integer counts, and the data matrix `X` contains the RNA-seq expression data as normalized counts.
 Note that only cells which are denoted as `"Keep"` in  the `merged_adata_object.uns["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
-The data is stored as a sparse matrix, where each column represents a cell or droplet, and each row represents a gene.
+The data is stored as a sparse matrix, where each column represents a cell or droplet, and each row represents a single ADT. 
 The `raw.X` and `X` matrices can be accessed with the following python code:
 
 ```python

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -167,7 +167,6 @@ Each such list will contain the following fields:
 | `cellassign_reference_source`  | If cell typing with `CellAssign` was performed and completed successfully, the source of the reference dataset (default is [`PanglaoDB`](https://panglaodb.se/))                                                                                                                                                                                                                   |
 | `cellassign_reference_version` | If cell typing with `CellAssign` was performed and completed successfully, the version of the reference dataset source. For references obtained from `PanglaoDB`, the version scheme is a date in ISO8601 format                                                                                                                                                                   |
 
-
 Unlike for {ref}`individual SingleCellExperiment objects<sce_file_contents:singlecellexperiment sample metadata>`, cluster algorithm parameters are not included in these metadata lists because clusters themselves are not included in the merged object.
 
 
@@ -450,22 +449,11 @@ merged_citeseq_adata_object.obs_names # matrix column names
 merged_citeseq_adata_object.var_names # matrix row names
 ```
 
+All of the per-cell data columns included in the `colData` of the `"adt"` alternative experiment in `SingleCellExperiment` merged objects are present in the `.obs` slot of the CITE-seq `AnnData` object.
+To see a full description of the included columns, see the section [on additional `SingleCellExperiment` components for CITE-seq libraries](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
 
-All of the per-cell data columns included in the `colData` of the `SingleCellExperiment` merged objects are present in the `.obs` slot of the `AnnData` object.
-To see a full description of the included columns, see the sections on [cell metrics](#singlecellexperiment-cell-metrics) and [sample metadata](#singlecellexperiment-sample-metadata) in [`Components of a SingleCellExperiment merged object`](#components-of-a-singlecellexperiment-merged-object).
 
-
-The data matrix, `X`, of the `AnnData` objects contain the primary ADT expression data as integer counts.
-Each column corresponds to a cell or droplet (in the same order as the main `AnnData` object), and each row corresponds to an antibody derived tag (ADT).
-Column names are again cell barcode sequences and row names are the antibody targets for each ADT.
-
-As with the RNA `AnnData` objects, in processed objects _only_ (`_processed_adt.hdf5`), the data matrix `X` contains the normalized ADT counts and the primary data can be found in `raw.X`.
-Note that only cells which are denoted as `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
-Note that this filtering information is also available in the `discard` column of the object's `.obs` slot, as described in the table below.
-However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances.
-In such cases the `AnnData` object will not contain a normalized expression matrix, but the primary data will still be stored in `X`.
-
-In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `obs` slot of each ADT-specific `AnnData` object.
+The following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `obs` slot of each ADT-specific `AnnData` object.
 
 | Column name                | Contents                                          |
 | -------------------------- | ------------------------------------------------- |

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -434,7 +434,7 @@ ADT data from CITE-seq experiments, when present, is available as a separate `An
 Merged `AnnData` objects contain two data matrices, each containing CITE-seq expression data for all libraries in a given ScPCA project combined into a single matrix.
 The data matrix `raw.X` of the merged `AnnData` object contains the CITE-seq expression data as primary integer counts, and the data matrix `X` contains the RNA-seq expression data as normalized counts.
 Note that only cells which are denoted as `"Keep"` in  the `merged_adata_object.uns["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
-The data is stored as a sparse matrix, where each column represents a cell or droplet, and each row represents a single ADT. 
+The data is stored as a sparse matrix, where each column represents a cell or droplet, and each row represents a single ADT.
 The `raw.X` and `X` matrices can be accessed with the following python code:
 
 ```python
@@ -453,25 +453,8 @@ All of the per-cell data columns included in the `colData` of the `"adt"` altern
 To see a full description of the included columns, see the section [on additional `SingleCellExperiment` components for CITE-seq libraries](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
 
 
-The following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `obs` slot of each ADT-specific `AnnData` object.
-
-| Column name                | Contents                                          |
-| -------------------------- | ------------------------------------------------- |
-| `zero.ambient`   | Indicates whether the cell has zero ambient contamination   |
-| `sum.controls` |  The sum of counts for all control features. Only present if negative/isotype control ADTs are present |
-| `high.controls`  | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present |
-| `ambient.scale` |  The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present |
-| `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present |
-| `discard`       | Indicates whether the cell should be discarded based on QC statistics. The `TRUE` and `FALSE` values in this column correspond, respectively, to values `"Discard"` and `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column                                                         |
-
-Metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the `.var` slot within the CITE-seq `AnnData` object:
-
-| Column name | Contents                                                       |
-| ----------- | -------------------------------------------------------------- |
-| `adt_id`  | Name or ID of the ADT                                              |
-| `mean-SCPCL000000`      | Mean ADT count across all cells/droplets. Only present for libraries with CITE-seq data                       |
-| `detected-SCPCL000000`  | Percent of cells in which the ADT was detected (ADT count > 0 ). Only present for libraries with CITE-seq data |
-| `target_type` | Whether each ADT is a target (`target`), negative/isotype control (`neg_control`), or positive control (`pos_control`). If this information was not provided, all ADTs will have been considered targets and will be labeled as `target` |
+In addition, all of the per-ADT data columns included in the `rowData` of the `"adt"` alternative experiment in `SingleCellExperiment` merged objects are present in the `.var` slot of the CITE-seq `AnnData` object.
+To see a full description of the included columns, see the section [on additional `SingleCellExperiment` components for CITE-seq libraries](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
 
 
-The `.uns` slot of the CITE-seq `AnnData` object contains a limited set of experiment metadata information, including a list of library IDs (`library_id`) and sample IDs (`sample_id`) included in the merged object.
+Finally, the `.uns` slot of the CITE-seq `AnnData` object contains a limited set of experiment metadata information, including a list of library IDs (`library_id`) and sample IDs (`sample_id`) included in the merged object.

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -393,3 +393,22 @@ merged_adata_object.var # gene metrics
 All of the per-gene data columns included in the `rowData` of the `SingleCellExperiment` objects are present in the `.var` slot of the `AnnData` object.
 Note that the `SingleCellExperiment` columns named `SCPCL000000-mean` and `SCPCL000000-detected` are instead named `SCPCL000000.mean` and `SCPCL000000.detected`, respectively, in the merged `AnnData` object.
 To see a full description of the included columns, see the [section on gene metrics in `Components of a SingleCellExperiment merged object`](#singlecellexperiment-gene-information-and-metrics).
+
+
+### AnnData experiment metadata
+
+A partial set of the metadata associated with {ref}`data processing <processing_information:Processing information>` is included in the `.uns` slot of the `AnnData` object as a list.
+
+```python
+merged_adata_object.uns # experiment metadata
+```
+
+The following items are available in the `.uns` slot:
+
+| Item name                      | Contents                                                                                                                                                                                                          |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `library_id`                   | A list of library IDs which are included in the merged object, each in the form `SCPCL000000`                                                                                                                   |
+| `sample_id`                    | A list of sample IDs which are included in the merged object, each in the form `SCPCS000000`                                                                                                                |
+| `merged_highly_variable_genes` | A list of highly variable genes used for performing dimensionality reduction on the merged object, determined using `scran::modelGeneVar`, specifying each library as a separate block, and `scran::getTopHVGs` |
+
+Additional experiment metadata is available in the {ref}`metadata TSV file included in the ScPCA Portal download folder <download_files:Metadata>`.

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -1,9 +1,9 @@
 # Merged objects
 
 Each merged object contains _combined information_ for all individual samples in the given ScPCA project.
-While each individual object, as described on the {ref}`Single-cell gene expression file contents page <sce_file_contents>`, contains quantified gene expression results for a single library, each merged object contains all gene expression results, including gene expression counts and metadata, for all libraries and samples in the given ScPCA project.
+While each individual object, as described on the {ref}`Single-cell gene expression file contents page <sce_file_contents:Single-cell gene expression file contents>`, contains quantified gene expression results for a single library, each merged object contains all gene expression results, including gene expression counts and metadata, for all libraries and samples in the given ScPCA project.
 This information includes quantified gene expression data, cell and gene metrics, and associated metadata for all libraries.
-See {ref}`the section on merged object processing <processing_information:merged objects` for more information on how these objects were prepared.
+See {ref}`the section on merged object processing <processing_information:merged objects>` for more information on how these objects were prepared.
 
 
 Merged objects are provided in two formats:
@@ -76,7 +76,7 @@ Columns representing quality control statistics were calculated using the [`scut
 | `scpca_filter`                   | Labels cells as either `Keep` or `Remove` based on filtering criteria (`prob_compromised` < 0.75 and number of unique genes detected > 200)                                                                                                                                                                                                                                                                                                            |
 | `adt_scpca_filter`               | If CITE-seq was performed, labels cells as either `Keep` or `Remove` based on ADT filtering criteria (`discard = TRUE` as determined by [`DropletUtils::CleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html))                                                                                                                                                                                                    |
 
-Unlike for {ref}`individual SCE objects<sce_file_contents:singlecellexperiment cell metrics`, cluster assignments are not included in the `colData`.
+Unlike for {ref}`individual SCE objects<sce_file_contents:singlecellexperiment cell metrics>`, cluster assignments are not included in the `colData`.
 
 
 ### SingleCellExperiment gene information and metrics
@@ -167,7 +167,8 @@ Each such list will contain the following fields:
 | `cellassign_reference_source`  | If cell typing with `CellAssign` was performed and completed successfully, the source of the reference dataset (default is [`PanglaoDB`](https://panglaodb.se/))                                                                                                                                                                                                                   |
 | `cellassign_reference_version` | If cell typing with `CellAssign` was performed and completed successfully, the version of the reference dataset source. For references obtained from `PanglaoDB`, the version scheme is a date in ISO8601 format                                                                                                                                                                   |
 
-Unlike for {ref}`individual SingleCellExperiment objects<sce_file_contents:singlecellexperiment sample metadata`, cluster algorithm parameters are not included in these metadata lists because clusters themselves are not included in the merged object.
+
+Unlike for {ref}`individual SingleCellExperiment objects<sce_file_contents:singlecellexperiment sample metadata>`, cluster algorithm parameters are not included in these metadata lists because clusters themselves are not included in the merged object.
 
 
 ### SingleCellExperiment sample metadata
@@ -333,7 +334,7 @@ In addition, the following columns in the `colData` slot `DataFrame` contain dem
 | `vireo_sampleid`            | Most likely sample as called by `vireo` (genetic demultiplexing) |
 
 
-Unlike in {ref}`individual SingleCellExperiment objects<sce_file_contents:additional SingleCellExperiment components for multiplexed libraries`, hashtag oligo (HTO) quantification will not be included in the merged `SingleCellExperiment` as an alternative experiment, as described in the ref`{frequently asked questions:faq:which projects can I download as a merged objects?}`.
+Unlike in {ref}`individual SingleCellExperiment objects<sce_file_contents:additional SingleCellExperiment components for multiplexed libraries>`, hashtag oligo (HTO) quantification will not be included in the merged `SingleCellExperiment` as an alternative experiment, as described in the ref`{frequently asked questions:faq:which projects can I download as a merged objects?}>`.
 
 
 ## Components of an AnnData merged object

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -282,7 +282,7 @@ As in the [main experiment's `colData` slot](#singlecellexperiment-cell-metrics)
 | `sum.controls` |  The sum of counts for all control features. Only present if negative/isotype control ADTs were used |
 | `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs were not used |
 | `ambient.scale` |  The relative amount of ambient contamination. Only present if negative/isotype control ADTs were not used |
-| `discard`  | Indicates whether the cell should be discarded based on ADT QC statistics |
+| `discard`  | Indicates whether the cell should be discarded based on ADT QC statistics. The `TRUE` and `FALSE` values in this column correspond, respectively, to values `"Discard"` and `"Keep"` in the `colData(merged_sce)$adt_scpca_filter` column |
 
 
 Metrics for each of the ADTs assayed can be found as a `DataFrame` stored as `rowData` within the alternative experiment:

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -147,7 +147,7 @@ For multiplex libraries where bulk RNA-seq data is available for the individual 
 - Cell genotypes were used to call sample of origin with [`vireo`](https://vireosnp.readthedocs.io) ([Huang _et al._ 2019](https://doi.org/10.1186/s13059-019-1865-2))
 
 The genetic demultiplexing calls are reported alongside HTO demultiplexing results for each library, but we again do not separate the individual samples.
-For information on where the demultiplexing calls can be found, see {ref}`the section on demultiplexing results in the SingleCellExperiment file contents. <sce_file_contents:demultiplexing results>`
+For information on where the demultiplexing calls can be found, see {ref}`the section on demultiplexing results in the SingleCellExperiment file contents<sce_file_contents:demultiplexing results>`.
 
 
 ## Spatial transcriptomics

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -476,11 +476,13 @@ Note that this filtering information is also available in the `discard` column o
 However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances.
 In such cases the `AnnData` object will not contain a normalized expression matrix, but the primary data will still be stored in `X`.
 
-QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `obs` slot of each ADT-specific `AnnData` object.
-This slot has the same contents as does the `colData` slot of `SingleCellExperiment` alternative experiment containing CITE-seq data, [as described above](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
+All of the per-cell data columns included in the `colData` of the `"adt"` alternative experiment in `SingleCellExperiment` objects are present in the `.obs` slot of the CITE-seq `AnnData` object.
+To see a full description of the included columns, see the section [on additional `SingleCellExperiment` components for CITE-seq libraries](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
 
-In addition, metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the `.var` slot within the `AnnData` object.
-This slot has the same contents as does the `rowData` slot of `SingleCellExperiment` alternative experiment containing CITE-seq data, [as described above](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
+
+In addition, all of the per-ADT data columns included in the `rowData` of the `"adt"` alternative experiment in `SingleCellExperiment` merged objects are present in the `.var` slot of the CITE-seq `AnnData` object.
+To see a full description of the included columns, see the section [on additional `SingleCellExperiment` components for CITE-seq libraries](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
+
 
 Finally, additional metadata for ADT processing can be found in the `.uns` slot of the `AnnData` object.
 This metadata slot has the same contents as the [RNA experiment metadata](#anndata-experiment-metadata), along with one additional field, `ambient_profile`, which holds a list of the ambient concentrations of each ADT.

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -247,7 +247,7 @@ In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`]
 | `high.controls`  | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present |
 | `ambient.scale` |  The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present |
 | `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present |
-| `discard`  | Indicates whether the cell should be discarded based on ADT QC statistics |
+| `discard`  | Indicates whether the cell should be discarded based on ADT QC statistics. The `TRUE` and `FALSE` values in this column correspond, respectively, to values `"Discard"` and `"Keep"` in the `colData(sce)$adt_scpca_filter` column |
 
 
 Metrics for each of the ADTs assayed can be found as a `DataFrame` stored as `rowData` within the alternative experiment:

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -472,31 +472,15 @@ Column names are again cell barcode sequences and row names are the antibody tar
 
 As with the RNA `AnnData` objects, in processed objects _only_ (`_processed_adt.hdf5`), the data matrix `X` contains the normalized ADT counts and the primary data can be found in `raw.X`.
 Only cells which are denoted as `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column (as described [above](#singlecellexperiment-cell-metrics)) have normalized expression values in the `X` matrix, and all other cells are assigned `NA` values.
-Note that this filtering information is also available in the `discard` column of the object's `.obs` slot, as described in the table below.
+Note that this filtering information is also available in the `discard` column of the object's `.obs` slot.
 However, as described in the {ref}`processed ADT data section <processing_information:Processed ADT data>`, normalization may fail under certain circumstances.
 In such cases the `AnnData` object will not contain a normalized expression matrix, but the primary data will still be stored in `X`.
 
-In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `obs` slot of each ADT-specific `AnnData` object.
+QC statistics from [`DropletUtils::cleanTagCounts()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/cleanTagCounts.html) can be found in the `obs` slot of each ADT-specific `AnnData` object.
+This slot has the same contents as does the `colData` slot of `SingleCellExperiment` alternative experiment containing CITE-seq data, [as described above](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
 
-| Column name     | Contents                                                                                                                      |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `zero.ambient`  | Indicates whether the cell has zero ambient contamination                                                                     |
-| `sum.controls`  | The sum of counts for all control features. Only present if negative/isotype control ADTs are present                         |
-| `high.controls` | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present |
-| `ambient.scale` | The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present                         |
-| `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present  |
-| `discard`       | Indicates whether the cell should be discarded based on QC statistics. The `TRUE` and `FALSE` values in this column correspond, respectively, to values `"Discard"` and `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column    |
-
-
-Metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the `.var` slot within the `AnnData` object:
-
-
-| Column name | Contents                                                       |
-| ----------- | -------------------------------------------------------------- |
-| `adt_id`    | Name or ID of the ADT                                         |
-| `mean`      | Mean ADT count across all cells/droplets                       |
-| `detected`  | Percent of cells in which the ADT was detected (ADT count > 0 ) |
-| `target_type` | Whether each ADT is a target (`target`), negative/isotype control (`neg_control`), or positive control (`pos_control`). If this information was not provided, all ADTs will have been considered targets and will be labeled as `target` |
+In addition, metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the `.var` slot within the `AnnData` object.
+This slot has the same contents as does the `rowData` slot of `SingleCellExperiment` alternative experiment containing CITE-seq data, [as described above](#additional-singlecellexperiment-components-for-cite-seq-libraries-with-adt-tags).
 
 Finally, additional metadata for ADT processing can be found in the `.uns` slot of the `AnnData` object.
 This metadata slot has the same contents as the [RNA experiment metadata](#anndata-experiment-metadata), along with one additional field, `ambient_profile`, which holds a list of the ambient concentrations of each ADT.

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -260,7 +260,7 @@ This data frame contains the following columns with statistics for each ADT:
 
 | Column name | Contents                                                       |
 | ----------- | -------------------------------------------------------------- |
-| `adt_name`  | Name or ID of the ADT                                          |
+| `adt_id`  | Name or ID of the ADT                                          |
 | `mean`      | Mean ADT count across all cells/droplets                       |
 | `detected`  | Percent of cells in which the ADT was detected (ADT count > 0 ) |
 | `target_type` | Whether each ADT is a target (`target`), negative/isotype control (`neg_control`), or positive control (`pos_control`). If this information was not provided, all ADTs will have been considered targets and will be labeled as `target` |
@@ -485,7 +485,7 @@ In addition, the following QC statistics from [`DropletUtils::cleanTagCounts()`]
 | `high.controls` | Indicates whether the cell has unusually high total control counts. Only present if negative/isotype control ADTs are present |
 | `ambient.scale` | The relative amount of ambient contamination. Only present if negative control ADTs are _not_ present                         |
 | `high.ambient`  | Indicates whether the cell has unusually high contamination. Only present if negative/isotype control ADTs are _not_ present  |
-| `discard`       | Indicates whether the cell should be discarded based on QC statistics. The `TRUE` and `FALSE` values in this column correspond, respectively, to values `"Discard"` and `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column                                                         |
+| `discard`       | Indicates whether the cell should be discarded based on QC statistics. The `TRUE` and `FALSE` values in this column correspond, respectively, to values `"Discard"` and `"Keep"` in the `adata_obj.obs["adt_scpca_filter"]` column    |
 
 
 Metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the `.var` slot within the `AnnData` object:
@@ -493,6 +493,7 @@ Metrics for each of the ADTs assayed can be found as a `pandas.DataFrame` in the
 
 | Column name | Contents                                                       |
 | ----------- | -------------------------------------------------------------- |
+| `adt_id`    | Name or ID of the ADT                                         |
 | `mean`      | Mean ADT count across all cells/droplets                       |
 | `detected`  | Percent of cells in which the ADT was detected (ADT count > 0 ) |
 | `target_type` | Whether each ADT is a target (`target`), negative/isotype control (`neg_control`), or positive control (`pos_control`). If this information was not provided, all ADTs will have been considered targets and will be labeled as `target` |

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -1,10 +1,8 @@
 #!/usr/bin/env Rscript
 #
 # Run spell check and save results
-# Adapted from: https://github.com/AlexsLemonade/refinebio-examples/blob/33cdeff66d57f9fe8ee4fcb5156aea4ac2dce07f/scripts/spell-check.R 
+# Adapted from: https://github.com/AlexsLemonade/refinebio-examples/blob/33cdeff66d57f9fe8ee4fcb5156aea4ac2dce07f/scripts/spell-check.R
 # and https://github.com/AlexsLemonade/training-modules/blob/04bea3d2707975e04b57b714ba8b709c77594706/scripts/spell-check.R
-
-library(magrittr)
 
 # Find .git root directory
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
@@ -17,9 +15,9 @@ files <- list.files(root_dir, pattern = '\\.md$', recursive = TRUE, full.names =
 
 
 # Run spell check
-spelling_errors <- spelling::spell_check_files(files, ignore = dictionary) %>%
-  data.frame() %>%
-  tidyr::unnest(cols = found) %>%
+spelling_errors <- spelling::spell_check_files(files, ignore = dictionary) |>
+  data.frame() |>
+  tidyr::unnest(cols = found) |>
   tidyr::separate(found, into = c("file", "lines"), sep = ":")
 
 # Print out how many spell check errors


### PR DESCRIPTION
Closes #241 🎉 

This PR _should_ 🤞 wrap up the merged object docs page. I added sections for experiment metadata (`uns`), reduced dimensions, and CITE-seq considerations.

I also made a couple other small changes:
- Gratuitous change to de-magrittr the spell check script
- Some parallel changes about that `discard` column, as in #261 
- Fixed some relative links throughout the docs that were not properly formatted, mostly a bunch of places that were missing a closing `>`!
- We missed a few spots in #258 to document `adt_id` (not `adt_name`!) in sce rowdata & anndata `.var`. 