### PR TITLE
Update code link colors

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -38,7 +38,7 @@ a, a:visited {
 
 a code span
 {
-  color: #003595;
+  color: #145ECC;
 }
 
 .wy-side-nav-search {

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -36,6 +36,11 @@ a, a:visited {
   color: #145ECC;
 }
 
+a code span
+{
+  color: #003595;
+}
+
 .wy-side-nav-search {
   padding: 56px 24px 24px 24px;
   position: relative;

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -41,10 +41,10 @@ a code span
   color: #145ECC;
 }
 
-a code span:hover
-{
+a:hover code span {
   color: #3091D1;
 }
+
 .wy-side-nav-search {
   padding: 56px 24px 24px 24px;
   position: relative;

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -41,6 +41,10 @@ a code span
   color: #145ECC;
 }
 
+a code span:hover
+{
+  color: #3091D1;
+}
 .wy-side-nav-search {
   padding: 56px 24px 24px 24px;
   position: relative;


### PR DESCRIPTION
Closes #170

This issue updates code link colors as suggested by @dvenprasad: 

>  The link color should be blue (#003595). 

Once approved to go into `development`, we can cherry-pick into the release PRs, so it can go out as part of the `AnnData` release.