### PR TITLE
Sync up development

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -20,7 +20,7 @@ assignees: ''
   - [ ] If a CHANGELOG entry was required, add the date to the entry's header as part of this PR.
 
 ### Creating a release
-- [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.
+- [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-docs/releases), choose `Draft a new release`.
 - [ ] In `Choose a tag`, use the current date as the release tag (`YYYY.MM.DD`), then click `Create a new tag: YYYY.MM.DD on publish`.
 - [ ] Write a description of the major changes in this release. You may want to start with the auto-generated release notes to save time.
 - [ ] Optional: If not all issues have been addressed, save a draft to return to later.

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -3,6 +3,7 @@ ADTs
 al
 alevin
 Alevin
+AnnData
 APA
 AnnData
 Aran

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,13 +13,17 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-------------------------------------------------->
 
 
-## PLACEHOLDER FOR CELL TYPING RELEASE DATE
+## PLACEHOLDER FOR CELL TYPING/COMMUNITY CONTRIBUTIONS RELEASE DATE
 
 * Cell type annotations are now included in each download.
 Cells were annotated using both [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html) and [`CellAssign`](https://github.com/Irrationone/cellassign).
   * You can find more information about how cell types were annotated in the {ref}`cell type annotation procedures section on the Processing Information page<processing_information:cell type annotation>`.
   For more information on locating cell type annotations and any associated processing information in the downloaded objects see {ref}`the Single-cell gene expression file contents page<sce_file_contents:components of a singlecellexperiment object>`.
 * Downloads will also contain a separate cell type report providing more information about cell type annotations, including comparisons between different cell type annotations and diagnostic assessments of cell type annotation reliability.
+* Sample metadata will now include two additional pieces of information which can be used to filter datasets: Whether the given sample is a patient-derived xenograft, and whether the sample is derived from a cell line.
+* This release additionally includes community-contributed projects.
+Community-contributed projects are 10x Genomics single-cell or single-nuclei datasets that have been processed with the ScPCA pipeline.
+Please refer to the [contributions page](https://scpca.alexslemonade.org/contribute) for more information about community contributions.
 
 
 ## PLACEHOLDER FOR RELEASE DATE

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -85,6 +85,9 @@ The cell type report, `SCPCL000000_celltype-report.html`, includes an overview o
 This report contains details on methodologies used for cell type annotation, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots.
 For more information on how cell types were annotated, see the section on {ref}`Cell type annotation <processing_information:cell type annotation>`.
 
+If the downloaded library was from a cell line sample, no cell type annotation will have been performed.
+Therefore, there will be no cell type report in the download for these libraries.
+
 ## Metadata
 
 The `single_cell_metadata.tsv` file is a tab-separated table with one row per library and the following columns.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -191,3 +191,9 @@ Second, although projects with multiplexing will have associated merged objects,
 This is because, although the ScPCA pipeline {ref}`reports demultiplexing results<processing_information:HTO demultiplexing>`, the libraries do not actually undergo demultiplexing itself.
 As there is no guarantee that a unique HTO was used for each sample in a given project, it would not necessarily be possible to determine which HTO corresponds to which sample in a merged object.
 Therefore, we do not merge the cellhash components of multiplexed projects.
+
+
+## Why doesn't my existing code work on a new download from the Portal?
+
+Although we try to maintain backward compatibility, new features added to the ScPCA Portal may result in downloads that are no longer compatible with code written with older downloads from the ScPCA Portal in mind.
+Please see our {ref}`CHANGELOG <CHANGELOG:CHANGELOG>` for a summary of changes that impact downloads from the Portal.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # ScPCA Portal Documentation
 
 This is the documentation for the [Single-cell Pediatric Cancer Atlas Portal](https://scpca.alexslemonade.org).
-The ScPCA Portal is a database of single-cell and single-nuclei RNA-sequencing data from pediatric cancer clinical samples and xenografts.
+The ScPCA Portal is a growing database of uniformly processed single-cell data from pediatric cancer tumors and model systems.
 
 ```{toctree}
 :maxdepth: 4

--- a/docs/processing_information.md
+++ b/docs/processing_information.md
@@ -85,6 +85,7 @@ During annotation, we additionally include an `"other"` cell type that does not 
 As a consequence, cells which `CellAssign` cannot confidently annotate from the full marker gene list are labeled as `"other"`.
 
 Please be aware that all cell type annotation reference datasets are derived from normal (not tumor) tissue.
+In addition, `CellAssign` annotation is only performed if there are at least 30 cells present in the `processed` object.
 
 Cell type annotation is not performed for cell line samples.
 For information on how to determine if a given sample was derived from a cell line, refer to section(s) describing {ref}`SingleCellExperiment file contents <sce_file_contents:singlecellexperiment sample metadata>` and/or {ref}`AnnData file contents <sce_file_contents:anndata cell metrics>`.


### PR DESCRIPTION
While cherry-picking #271 into the cell type release branch, I noticed a couple changes had apparently happened in the cell type release branch only which were not properly reflected in `development`. This PR merges the cell type branch into `development`, so branches should now be more in sync!