### PR TITLE
Update name of age field

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,5 +85,5 @@ html_context = {
     "display_github": True,
     "github_user": "Alexslemonade",
     "github_repo": "scpca-docs",
-    "github_version": "main/docs/",
+    "github_version": "main/",
 }

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -102,7 +102,7 @@ The `single_cell_metadata.tsv` file is a tab-separated table with one row per li
 | `submitter_id`    | Original sample identifier from submitter                      |
 | `participant_id`  | Unique id corresponding to the donor from which the sample was obtained |
 | `submitter`       | Submitter name/id                                              |
-| `age`             | Age at time sample was obtained                                |
+| `age_at_diagnosis` | Age at time sample was obtained                               |
 | `sex`             | Sex of patient that the sample was obtained from               |
 | `diagnosis`       | Tumor type                                                     |
 | `subdiagnosis`    | Subcategory of diagnosis or mutation status (if applicable)    |


### PR DESCRIPTION
When downloading data from the portal, I noticed that the docs did not include the changes to the `age` field in the metadata table, so this updates that.

I also noticed that the "edit on github" link was going to wrong place (a 404 with an extra `docs/` in the path, so I tried to fix that too. 