### PR TITLE
Mention that no merged objects are provided for larger projects

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -192,6 +192,10 @@ There are two types of projects for which merged objects are not available:
     - Although the ScPCA pipeline {ref}`reports demultiplexing results<processing_information:HTO demultiplexing>`, it does not actually perform demultiplexing.
     As there is no guarantee that a unique HTO was used for each sample in a given project, it would not necessarily be possible to determine which HTO corresponds to which sample in a merged object.
 
+- Projects containing more than 50 samples
+    - The more samples that are included in a merged object, the larger the object, and the more difficult it will be to work with that object in R or Python.
+    Because of this, we do not provide merged objects for projects with more than 50 samples as the size of the merged object is too large.
+
 ## Why doesn't my existing code work on a new download from the Portal?
 
 Although we try to maintain backward compatibility, new features added to the ScPCA Portal may result in downloads that are no longer compatible with code written with older downloads from the ScPCA Portal in mind.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -182,7 +182,7 @@ Please refer to {ref}`the getting started with a merged object section<getting_s
 ## Which projects can I download as merged objects?
 
 Most projects in the ScPCA Portal are available for download as a merged object.
-There are two types of projects for which merged objects are not available:
+There are three types of projects for which merged objects are not available:
 
 - Projects comprised of spatial transcriptomics
     - As described in {ref}`the spatial transcriptomics processing section<processing_information:spatial transcriptomics>`, no post-processing is performed on these libraries after running Space Ranger.

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -311,28 +311,8 @@ metadata(altExp(merged_sce, "adt")) # adt metadata
 
 ### Additional SingleCellExperiment components for multiplexed libraries
 
-
-Multiplexed libraries will contain several additional per-cell data columns in the `colData` slot (accessed with `colData(merged_sce)` [as above](#singlecellexperiment-cell-metrics)).
-
-The following columns in the `colData` slot `DataFrame` contain cellhash QC statistics for multiplexed libraries:
-
-| Column name                 | Contents                                                         |
-| --------------------------- | ---------------------------------------------------------------- |
-| `altexps_cellhash_sum`      | UMI count for cellhash HTOs                                      |
-| `altexps_cellhash_detected` | Number of HTOs detected per cell (HTO count > 0 )                |
-| `altexps_cellhash_percent`  | Percent of `total` UMI count from HTO reads                      |
-
-In addition, the following columns in the `colData` slot `DataFrame` contain demultiplexing results, although note that demultiplexing itself was not performed:
-
-| Column name                 | Contents                                                         |
-| --------------------------- | ---------------------------------------------------------------- |
-| `hashedDrops_sampleid`      | Most likely sample as called by `DropletUtils::hashedDrops`      |
-| `HTODemux_sampleid`         | Most likely sample as called by `Seurat::HTODemux`               |
-| `vireo_sampleid`            | Most likely sample as called by `vireo` (genetic demultiplexing) |
-
-
-Unlike in {ref}`individual SingleCellExperiment objects<sce_file_contents:additional SingleCellExperiment components for multiplexed libraries>`, hashtag oligo (HTO) quantification will not be included in the merged `SingleCellExperiment` as an alternative experiment, as described in the ref`{frequently asked questions:faq:which projects can I download as a merged objects?}>`.
-
+Merged objects are not available for any projects that contain multiplexed libraries.
+As there is no guarantee that a unique HTO was used for each sample in a given project, it would not necessarily be possible to determine which HTO corresponds to which sample in a merged object.
 
 ## Components of an AnnData merged object
 

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -312,7 +312,7 @@ metadata(altExp(merged_sce, "adt")) # adt metadata
 ### Additional SingleCellExperiment components for multiplexed libraries
 
 Merged objects are not available for any projects that contain multiplexed libraries.
-As there is no guarantee that a unique HTO was used for each sample in a given project, it would not necessarily be possible to determine which HTO corresponds to which sample in a merged object.
+This is because there is no guarantee that a unique HTO was used for each sample in a given project, so it would not necessarily be possible to determine which HTO corresponds to which sample in a merged object.
 
 ## Components of an AnnData merged object
 


### PR DESCRIPTION
Closes #282 

Here I updated the docs to account for projects with missing merged objects. 

- I noticed that we still describe the contents of multiplexed merged objects even though we don't provide them. I removed that section and replaced with a note that we don't merge any projects with multiplexed libraries. 
- I updated the FAQ with another bullet for large projects. I used a cut-off of 50 since both projects with > 50 samples failed and projects with 45 samples were created without issues. I just mentioned that we don't include them because they are too large and hard to work with. 
