### PR TITLE
Merged object changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,13 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+## PLACEHOLDER FOR MERGED RELEASE DATE
+
+
+* Most projects can now be downloaded as a single object containing all libraries merged together, either in `SCE` or `AnnData` formats
+  * Merged project downloads will contain a brief summary report about the merged object as well as the individual QC and cell type annotation reports for all libraries in the merged object.
+  * See our {ref}`documentation on how merged objects were created<processing_information:merged objects>` and our {ref}`FAQ about merged objects<faq:When should I download a project as a merged object?>` for more information.
+
 
 ## PLACEHOLDER FOR CELL TYPING/COMMUNITY CONTRIBUTIONS RELEASE DATE
 
@@ -26,7 +33,7 @@ Community-contributed projects are 10x Genomics single-cell or single-nuclei dat
 Please refer to the [contributions page](https://scpca.alexslemonade.org/contribute) for more information about community contributions.
 
 
-## PLACEHOLDER FOR RELEASE DATE
+## 2024.03.08
 
 * Downloads for most projects are now available in [`AnnData`](https://anndata.readthedocs.io/en/latest/index.html) format as HDF5 files.
 Multiplexed samples are not yet supported.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,12 +15,12 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER FOR MERGED RELEASE DATE
 
 
-* When downloading data for an entire project, you will now have the option to download a single file with a single merged object containing all gene expression and metadata for all samples in that project. 
+* When downloading data for an entire project, you have the option to download a single file with a single merged object containing all gene expression and metadata for all samples in that project. 
   * These merged objects are available as either `SingleCellExperiment` (`.rds` files) or `AnnData` (`.hdf5` files) objects.
-  * This option is now available for most projects. 
+  * This option is available for most projects. 
   If the project you are interested in does not have this option, see our {ref}`FAQ on which projects can be downloaded as merged objects<faq:Which projects can I download as merged objects?>`. 
-  * Merged project downloads will contain a brief summary report about the merged object as well as the individual QC and cell type annotation reports for all libraries in the merged object.
-  * See our {ref}`documentation on how merged objects were created<processing_information:merged objects>` and our {ref}`FAQ about merged objects<faq:When should I download a project as a merged object?>` for more information.
+* Merged project downloads will contain a brief summary report about the merged object as well as the individual QC and cell type annotation reports for all libraries in the merged object.
+* See our {ref}`documentation on how merged objects were created<processing_information:merged objects>` and our {ref}`FAQ about merged objects<faq:When should I download a project as a merged object?>` for more information.
 
 
 ## PLACEHOLDER FOR CELL TYPING/COMMUNITY CONTRIBUTIONS RELEASE DATE

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,10 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER FOR MERGED RELEASE DATE
 
 
-* Most projects can now be downloaded as a single object containing all libraries merged together, either in `SCE` or `AnnData` formats
+* When downloading data for an entire project, you will now have the option to download a single file with a single merged object containing all gene expression and metadata for all samples in that project. 
+  * These merged objects are available as either `SingleCellExperiment` (`.rds` files) or `AnnData` (`.hdf5` files) objects.
+  * This option is now available for most projects. 
+  If the project you are interested in does not have this option, see our {ref}`FAQ on which projects can be downloaded as merged objects<faq:Which projects can I download as merged objects?>`. 
   * Merged project downloads will contain a brief summary report about the merged object as well as the individual QC and cell type annotation reports for all libraries in the merged object.
   * See our {ref}`documentation on how merged objects were created<processing_information:merged objects>` and our {ref}`FAQ about merged objects<faq:When should I download a project as a merged object?>` for more information.
 


### PR DESCRIPTION
Towards #268 

This PR adds a changelog entry for merged objects. Do we want more or less detail here?

Note also that this file doesn't have the cell type annotation changelog date in it yet, since we haven't yet dated it, so we'll need to keep tabs on that. It also didn't have the anndata one either (i guess we never merged `main` back into `dev`), so I manually added it.