### PR TITLE
Add today's date to changelog for merged objects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,13 +12,13 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
-## PLACEHOLDER FOR MERGED RELEASE DATE
+## 2024.04.18
 
 
-* When downloading data for an entire project, you have the option to download a single file with a single merged object containing all gene expression and metadata for all samples in that project. 
+* When downloading data for an entire project, you have the option to download a single file with a single merged object containing all gene expression and metadata for all samples in that project.
   * These merged objects are available as either `SingleCellExperiment` (`.rds` files) or `AnnData` (`.hdf5` files) objects.
-  * This option is available for most projects. 
-  If the project you are interested in does not have this option, see our {ref}`FAQ on which projects can be downloaded as merged objects<faq:Which projects can I download as merged objects?>`. 
+  * This option is available for most projects.
+  If the project you are interested in does not have this option, see our {ref}`FAQ on which projects can be downloaded as merged objects<faq:Which projects can I download as merged objects?>`.
 * Merged project downloads will contain a brief summary report about the merged object as well as the individual QC and cell type annotation reports for all libraries in the merged object.
 * See our {ref}`documentation on how merged objects were created<processing_information:merged objects>` and our {ref}`FAQ about merged objects<faq:When should I download a project as a merged object?>` for more information.
 


### PR DESCRIPTION
In preparation for the release of merged objects today, this adds the date as the header for the changelog regarding merged objects. Once this is merged into `development` then #285 will be ready to go in and we can do a release. 