### PR TITLE
Add note about demux_methods

### DIFF
--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -312,7 +312,7 @@ Note that in the unfiltered `SingleCellExperiment` objects, this may include has
 ### Demultiplexing results
 
 Demultiplexing results are included only in the `filtered` and `processed` objects.
-The demultiplexing methods applied for these objects are described in the {ref}`multiplex data processing section <processing_information:Multiplexed libraries>`.
+A list of the demultiplexing methods applied for these objects can be found in `metadata(sce)$demux_methods` and are described in the {ref}`multiplex data processing section <processing_information:Multiplexed libraries>`.
 
 Demultiplexing analysis adds the following additional fields to the `colData(sce)` data frame:
 


### PR DESCRIPTION
Following the updates in https://github.com/AlexsLemonade/scpca-nf/pull/742, this documents the addition of `metadata(sce)$demux_methods` in filtered and processed objects. 
