### PR TITLE
Add preprint info to CHANGELOG

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -30,6 +30,7 @@ demultiplexed
 demultiplexing
 demux
 Dobin
+DOI
 DropletUtils
 embeddings
 Ensembl

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER FOR H5AD RELEASE DATE
 
 * AnnData files now have the extension `.h5ad` instead of `.hdf5`.
+* A preprint describing the ScPCA Portal and the pipeline used to process data is now available on _bioRxiv_ ([DOI: 10.1101/2024.04.19.590243](https://doi.org/10.1101/2024.04.19.590243)).
+  Please cite this preprint when citing the ScPCA Portal (see {ref}`How to Cite <citation:how to cite>` for more information).
 
 ## 2024.04.18
 


### PR DESCRIPTION
This doesn't affect downloads except for the citation information in the README. It seemed useful to include in the CHANGELOG anyway.