### PR TITLE
Add date for H5 change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
-## PLACEHOLDER FOR H5AD RELEASE DATE
+## 2024.04.26
 
 * AnnData files now have the extension `.h5ad` instead of `.hdf5`.
 * A preprint describing the ScPCA Portal and the pipeline used to process data is now available on _bioRxiv_ ([DOI: 10.1101/2024.04.19.590243](https://doi.org/10.1101/2024.04.19.590243)).


### PR DESCRIPTION
We anticipate that the H5 changes will go live on Friday/ over the weekend. This adds the date for Friday to the changelog entry. 