### PR TITLE
Add changelog for metadata only downloads

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,13 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+## 2024.06.20
+
+* Metadata for all samples in a specified project can now be downloaded as a tab-separated values file.
+  * This allows users to download and view all sample, library, project, and processing related metadata for all samples in a project without having to download all data in a project.
+  * Metadata is also included with each data download.
+  * For more information on what to expect in the metadata files, see the {ref}`metadata section of the Downloadable files page <download_files:metadata`.
+
 ## 2024.04.26
 
 * `AnnData` objects are stored in files that now have the extension `.h5ad` instead of `.hdf5`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## 2024.06.20
 
 * Metadata for all samples in a specified project can now be downloaded as a tab-separated values file.
-  * This allows users to download and view all sample, library, project, and processing related metadata for all samples in a project without having to download all data in a project.
+  * This allows users to download and view all sample, library, project, and processing-related metadata for all samples in a project without having to download all data in a project.
   * Metadata is also included with each data download.
   * For more information on what to expect in the metadata files, see the {ref}`metadata section of the Downloadable files page <download_files:metadata`.
 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -162,9 +162,9 @@ This file will contain fields equivalent to those found in the `single_cell_meta
 Metadata for all samples on the Portal is available to download separately from gene expression data downloads.
 Each project page has an option to download metadata for all of its samples as a single zip file containing the `metadata.tsv` file and a `README.md` file.
 Project-specific metadata will contain all columns listed in [the above table](#metadata) and any additional project-specific columns, such as treatment or outcome.
-
+<!--
 Additionally, the metadata for all samples on the Portal is available and contains the metadata for all samples available on the Portal.
-The Portal-wide metadata will contain all columns listed in [the above table](#metadata).
+The Portal-wide metadata will contain all columns listed in [the above table](#metadata).-->
 
 ## Multiplexed sample libraries
 


### PR DESCRIPTION
Closes #315 

This PR adds a changelog for the upcoming release of metadata only downloads (expected on Thursday). Here I'm only adding the information about the project metadata downloads as we are planning to release portal wide metadata next sprint and still have some items to discuss. Because of this I also commented out the line that describes portal wide metadata. Are we okay with this? I'll file an issue to un comment out that line and then probably another changelog and release for when that metadata is available. 

I plan to release these docs on Thursday and will check with @davidsmejia before release. If we need to adjust the date for any reason we can always do that prior to release. 