### PR TITLE
Prep docs for release of portal wide metadata

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,11 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+## PLACEHOLDER FOR PORTAL WIDE METADATA
+
+* Metadata for all samples from all projects on the Portal can now be downloaded as one tab-separated values file.
+* For more information on what to expect in the metadata file, see the {ref}`metadata section of the Downloadable files page <download_files:metadata`.
+
 ## 2024.06.20
 
 * Metadata for all samples in a specified project can now be downloaded as a tab-separated values file.

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -162,9 +162,9 @@ This file will contain fields equivalent to those found in the `single_cell_meta
 Metadata for all samples on the Portal is available to download separately from gene expression data downloads.
 Each project page has an option to download metadata for all of its samples as a single zip file containing the `metadata.tsv` file and a `README.md` file.
 Project-specific metadata will contain all columns listed in [the above table](#metadata) and any additional project-specific columns, such as treatment or outcome.
-<!--
+
 Additionally, the metadata for all samples on the Portal is available and contains the metadata for all samples available on the Portal.
-The Portal-wide metadata will contain all columns listed in [the above table](#metadata).-->
+The Portal-wide metadata will contain all columns listed in [the above table](#metadata).
 
 ## Multiplexed sample libraries
 


### PR DESCRIPTION
Closes #318 

Here I uncommented out the section of the docs that described the portal wide metadata and added a changelog entry. I kept the changelog entry pretty brief, but let me know if I should expand any more there? 

Before we actually release these docs we will need to add a date to the changelog. 