### PR TITLE
Fix broken links in changelog in development

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,14 +15,14 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER FOR PORTAL WIDE METADATA
 
 * Metadata for all samples from all projects on the Portal can now be downloaded in a single tab-separated values file.
-* For more information on what to expect in the metadata file, see the {ref}`metadata section of the Downloadable files page <download_files:metadata`.
+* For more information on what to expect in the metadata file, see the {ref}`metadata section of the Downloadable files page <download_files:metadata>`.
 
 ## 2024.06.20
 
 * Metadata for all samples in a specified project can now be downloaded as a tab-separated values file.
   * This allows users to download and view all sample, library, project, and processing-related metadata for all samples in a project without having to download all data in a project.
   * Metadata is also included with each data download.
-  * For more information on what to expect in the metadata files, see the {ref}`metadata section of the Downloadable files page <download_files:metadata`.
+  * For more information on what to expect in the metadata files, see the {ref}`metadata section of the Downloadable files page <download_files:metadata>`.
 
 ## 2024.04.26
 


### PR DESCRIPTION
Just mirroring the changes made in #322 and also fixing the link in the new changelog additions from #320. 
