### PR TITLE
Updates to AnnData contents based on new scanpy compatibility

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -179,7 +179,7 @@ This list can be accessed using the following command in the `AnnData` objects:
 processed_adata.uns["highly_variable_genes"]
 ```
 
-Additionally, the `AnnData` objects contain a column in the `.var` slot, `"highly_variable"` indicating whether or not a gene is found in the list of highly variable genes.
+Additionally, the `AnnData` objects contain a column in the `.var` slot, `"highly_variable"`, indicating whether or not a gene is found in the list of highly variable genes.
 
 ### Clustering
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -146,10 +146,10 @@ Dimensionality reduction results can be accessed in the `AnnData` objects using 
 
 ```python
 # principal component analysis results
-processed_adata.obsm["X_PCA"]
+processed_adata.obsm["X_pca"]
 
 # UMAP results
-processed_adata.obsm["X_UMAP"]
+processed_adata.obsm["X_umap"]
 ```
 
 See below for more resources on dimensionality reduction:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -179,6 +179,8 @@ This list can be accessed using the following command in the `AnnData` objects:
 processed_adata.uns["highly_variable_genes"]
 ```
 
+Additionally, the `AnnData` objects contain a column in the `.var` slot, `"highly_variable"` indicating whether or not a gene is found in the list of highly variable genes.
+
 ### Clustering
 
 Cluster assignments obtained from [Graph-based clustering](http://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph) is also available in the processed objects.

--- a/docs/merged_objects.md
+++ b/docs/merged_objects.md
@@ -394,15 +394,15 @@ Additional experiment metadata is available in the {ref}`metadata TSV file inclu
 
 ### AnnData dimensionality reduction results
 
-The merged `AnnData` object contains a slot `.obsm` with both principal component analysis (`X_PCA`) and UMAP (`X_UMAP`) results.
+The merged `AnnData` object contains a slot `.obsm` with both principal component analysis (`X_pca`) and UMAP (`X_umap`) results.
 
 For information on how PCA and UMAP results were calculated see the {ref}`section on processed gene expression data <processing_information:Processed gene expression data>`.
 
 The following command can be used to access the PCA and UMAP results:
 
 ```python
-merged_adata_object.obsm["X_PCA"] # pca results
-merged_adata_object.obsm["X_UMAP"] # umap results
+merged_adata_object.obsm["X_pca"] # pca results
+merged_adata_object.obsm["X_umap"] # umap results
 ```
 
 

--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -427,6 +427,7 @@ The `AnnData` object also includes the following additional gene-level metadata 
 | Column name   | Contents                                                         |
 | ------------- | ---------------------------------------------------------------- |
 | `is_feature_filtered` | Boolean indicating if the gene or feature is filtered out in the normalized matrix but is present in the raw matrix     |
+| `highly_variable` | Boolean indicating if the gene or feature is found in the highly variable gene list determined using `scran::modelGeneVar` and `scran::getTopHVGs`. Only present for `processed` objects   |
 
 
 ### AnnData experiment metadata
@@ -447,11 +448,12 @@ The `AnnData` object also includes the following additional items in the `.uns` 
 | Item name   | Contents                                                         |
 | ------------- | ---------------------------------------------------------------- |
 | `schema_version` | CZI schema version used for `AnnData` formatting |
+| `pca` | A dictionary object containing the parameters and variance weights associated with the PCA matrix found in `.obsm["X_pca"]`. Only available for processed objects |
 
 
 ### AnnData dimensionality reduction results
 
-The H5AD file containing the processed `AnnData` object (`_processed_rna.h5ad`) contains a slot `.obsm` with both principal component analysis (`X_PCA`) and UMAP (`X_UMAP`) results.
+The H5AD file containing the processed `AnnData` object (`_processed_rna.h5ad`) contains a slot `.obsm` with both principal component analysis (`X_pca`) and UMAP (`X_umap`) results stored as a `numpy.ndarray`.
 For all other H5AD files, the `.obsm` slot will be empty as no dimensionality reduction was performed.
 
 For information on how PCA and UMAP results were calculated see the {ref}`section on processed gene expression data <processing_information:Processed gene expression data>`.
@@ -459,8 +461,8 @@ For information on how PCA and UMAP results were calculated see the {ref}`sectio
 The following command can be used to access the PCA and UMAP results:
 
 ```python
-adata_object.obsm["X_PCA"] # pca results
-adata_object.obsm["X_UMAP"] # umap results
+adata_object.obsm["X_pca"] # pca results
+adata_object.obsm["X_umap"] # umap results
 ```
 
 ### Additional AnnData components for CITE-seq libraries (with ADT tags)


### PR DESCRIPTION
Closes #337 

Related to changes described in https://github.com/AlexsLemonade/scpca-nf/issues/773 and made in https://github.com/AlexsLemonade/scpca-nf/pull/774. 

Here I'm accounting for the new changes to contents in the individual and merged AnnData objects. Both objects have the following changes: 

- `X_PCA` and `X_UMAP` have been renamed to `X_pca` and `X_umap`
- `highly_variable` is now a column in the `.var` slot indicating if a gene is part of the HVG list 

Just the individual objects will have: 

- A new `.uns["pca"]` object that contains information about parameters and variance for PCA. I didn't describe every element of this, because I think if someone is using it they know what they're doing. Let me know if the explanation that I included is okay or if I should add more detail. 

I made the changes in the SCE contents file (in the AnnData section) and the merged object file. I think that should be everything. 