### PR TITLE
Add `Copy Download Link` FAQ

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,11 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+## PLACEHOLDER YYYY.MM.DD
+
+* You can now use a `Copy Download Link` button to get download links for projects on the ScPCA Portal.
+Please see the {ref}`FAQ <faq:what does the copy download link button do>` for more information.
+
 ## 2024.09.24
 
 * Metadata for all samples from all projects on the Portal can now be downloaded in a single tab-separated values file.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER YYYY.MM.DD
 
 * You can now use a `Copy Download Link` button to get download links for projects on the ScPCA Portal.
-Please see the {ref}`FAQ <faq:What does the \`Copy Download Link\` button do?>` for more information.
+Please see the {ref}`FAQ <faq:What does the `Copy Download Link` button do?>` for more information.
 
 ## 2024.09.24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
-## PLACEHOLDER YYYY.MM.DD
+## 2024.10.01
 
 * You can now use a `Copy Download Link` button to get download links for projects on the ScPCA Portal.
 Please see the {ref}`FAQ <faq:What does the Copy Download Link button do?>` for more information.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER YYYY.MM.DD
 
 * You can now use a `Copy Download Link` button to get download links for projects on the ScPCA Portal.
-Please see the {ref}`FAQ <faq:What does the `Copy Download Link` button do?>` for more information.
+Please see the {ref}`FAQ <faq:What does the Copy Download Link button do?>` for more information.
 
 ## 2024.09.24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER YYYY.MM.DD
 
 * You can now use a `Copy Download Link` button to get download links for projects on the ScPCA Portal.
-Please see the {ref}`FAQ <faq:What does the Copy Download Link button do?>` for more information.
+Please see the {ref}`FAQ <faq:What does the \`Copy Download Link\` button do?>` for more information.
 
 ## 2024.09.24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## PLACEHOLDER YYYY.MM.DD
 
 * You can now use a `Copy Download Link` button to get download links for projects on the ScPCA Portal.
-Please see the {ref}`FAQ <faq:what does the copy download link button do>` for more information.
+Please see the {ref}`FAQ <faq:What does the Copy Download Link button do?>` for more information.
 
 ## 2024.09.24
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -231,3 +231,13 @@ If a sample you downloaded previously is no longer available, a submitter has re
 We process and release all data provided to us on the Portal, without filtering out samples based on quality.
 Instead, we provide a QC report with each download so that users may assess library quality themselves.
 However, we respect submitters' requests to remove samples if they have deemed they are low quality based on their own analyses.
+
+## What does the `Copy Download Link` button do?
+
+The copy download link allows you to copy the URL to download a project using a command line tool such as [`wget`](https://www.gnu.org/software/wget/) or [`curl`](https://curl.se/). 
+It does not trigger a download via your web browser, so you must take additional steps to download the data with another tool.
+
+Download links expire in 7 days, but you can generate a new link on the ScPCA Portal as often as needed.
+
+Download links are only available for projects (i.e., not for downloading individual samples).
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -232,7 +232,7 @@ We process and release all data provided to us on the Portal, without filtering 
 Instead, we provide a QC report with each download so that users may assess library quality themselves.
 However, we respect submitters' requests to remove samples if they have deemed they are low quality based on their own analyses.
 
-## What does the `Copy Download Link` button do?
+## What does the Copy Download Link button do?
 
 The copy download link allows you to copy the URL to download a project using a command line tool such as [`wget`](https://www.gnu.org/software/wget/) or [`curl`](https://curl.se/). 
 It does not trigger a download via your web browser, so you must take additional steps to download the data with another tool.


### PR DESCRIPTION
## Purpose

I am adding an FAQ that explains the Copy Download Link button on the Portal. Per the issue, I am also adding a short CHANGELOG entry.

### Issue addressed

<!-- What issue does this address? -->
<!-- This will often be a release issue. -->

Closes #345 - I am choosing to go directly to `main` here, given the small scope, and we'll follow up with a merge `main` -> `development`.


## Checklist for publishing to `main`

<!-- Use this when releasing features -->

- [x] This branch contains all commits/content ready to be released.
- [ ] The most recent CHANGELOG entry includes a date.
If this release required a CHANGELOG entry, it should be today's date.
