### PR TITLE
Update cell count-related fields description

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -13,6 +13,7 @@ basepairs
 benchmarking
 Bioinformatics
 bioRxiv
+Bruford
 cDNA
 cellhash
 cellhashing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,14 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+## PLACEHOLDER
+
+* Some cell count-related fields in downloadable metadata have changed.
+  * `sample_cell_count_estimate` has been removed from downloads for non-multiplexed samples.
+  * A new field that indicates the estimated number of cells from a sample for a given library—`demux_sample_cell_estimate`—has been added to downloadable metadata for multiplexed samples.
+    This replaces the `sample_cell_estimate` field, which has been removed.
+* Fusion nomenclature has been standardized using the double colon recommendation from the HUGO Gene Nomenclature Committee ([Bruford et al. 2021](https://doi.org/10.1038/s41375-021-01436-6)) in downloadable metadata.
+
 ## 2024.10.01
 
 * You can now use a `Copy Download Link` button to get download links for projects on the ScPCA Portal.

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -182,7 +182,7 @@ Because we do not perform demultiplexing to separate cells from multiplexed libr
 For more on the specific contents of multiplexed library `SingleCellExperiment` objects, see the {ref}`Additional SingleCellExperiment components for multiplexed libraries <sce_file_contents:additional singlecellexperiment components for multiplexed libraries>` section.
 
 The [metadata file](#metadata) for multiplexed libraries (`single_cell_metadata.tsv`) will have the same format as for individual samples, but each row will represent a particular sample/library pair, meaning that there may be multiple rows for each `scpca_library_id`, one for each `scpca_sample_id` within that library.
-In addition, an estimate of the total number of cells for each sample after demultiplexing will be found in the `sample_cell_estimate` (as opposed to the `sample_cell_count_estimate` column used for non-multiplexed samples).
+In addition, an estimate of the number of cells from the sample in the library in the sample/library pair will be present in the `demux_sample_cell_estimate` column.
 
 
 ## Merged object downloads

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -182,7 +182,7 @@ Because we do not perform demultiplexing to separate cells from multiplexed libr
 For more on the specific contents of multiplexed library `SingleCellExperiment` objects, see the {ref}`Additional SingleCellExperiment components for multiplexed libraries <sce_file_contents:additional singlecellexperiment components for multiplexed libraries>` section.
 
 The [metadata file](#metadata) for multiplexed libraries (`single_cell_metadata.tsv`) will have the same format as for individual samples, but each row will represent a particular sample/library pair, meaning that there may be multiple rows for each `scpca_library_id`, one for each `scpca_sample_id` within that library.
-In addition, an estimate of the number of cells from the sample in the library in the sample/library pair will be present in the `demux_sample_cell_estimate` column.
+In addition, the `demux_sample_cell_estimate` column will contain an estimate of the number of cells from the sample in the library (after demultiplexing) in the sample/library pair.
 
 
 ## Merged object downloads

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -121,7 +121,6 @@ Each row corresponds to a unique sample/library combination and contains the fol
 | `technology`      | 10x kit used to process library                                |
 | `total_reads` | Total number of reads processed by `salmon` |
 | `mapped_reads` |  Number of reads successfully mapped |
-| `sample_cell_count_estimate` | Total number of cells found in the filtered object for all libraries from a given sample |
 | `unfiltered_cells` | Total number of cells detected by `alevin-fry` |
 | `filtered_cell_count` | Number of cells after filtering with `emptyDrops`          |
 | `filtered_cells` | Number of cells after filtering with `emptyDrops`. Only present for multiplexed libraries |


### PR DESCRIPTION
Closes #354 
Closes #355 

Here, I'm removing `sample_cell_count_estimate` from the table describing metadata in non-multiplexed samples and adding a sentence describing the new `demux_sample_cell_estimate` in the multiplexed section.