### PR TITLE
Replace `demux_sample_cell_estimate` with `demux_cell_count_estimate`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,17 +14,17 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 
 ## 2024.11.14
 
-* Recent versions of the raw count matrices in `SingleCellExperiment` and `AnnData` objects were not rounded. 
+* Recent versions of the raw count matrices in `SingleCellExperiment` and `AnnData` objects were not rounded.
 The raw counts are now rounded to integer values in agreement with the documentation.
 * Some project-specific metadata columns were renamed for uniformity:
   * Columns previously labeled as `mycn_status` or similar with a gene name prefix are capitalized `MYCN_status`.
-  * Columns that were previously labeled with sentence case are now all lower case.  
+  * Columns that were previously labeled with sentence case are now all lower case.
 
 ## 2024.10.14
 
 * Some cell count-related fields in downloadable metadata have changed.
   * `sample_cell_count_estimate` has been removed from downloads for non-multiplexed samples.
-  * A new field that indicates the estimated number of cells from a sample for a given library—`demux_sample_cell_estimate`—has been added to downloadable metadata for multiplexed samples.
+  * A new field that indicates the estimated number of cells from a sample for a given library—`demux_cell_count_estimate`—has been added to downloadable metadata for multiplexed samples.
     This replaces the `sample_cell_estimate` field, which has been removed.
 * Fusion nomenclature has been standardized using the double colon recommendation from the HUGO Gene Nomenclature Committee ([Bruford et al. 2021](https://doi.org/10.1038/s41375-021-01436-6)) in downloadable metadata.
 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -182,7 +182,7 @@ Because we do not perform demultiplexing to separate cells from multiplexed libr
 For more on the specific contents of multiplexed library `SingleCellExperiment` objects, see the {ref}`Additional SingleCellExperiment components for multiplexed libraries <sce_file_contents:additional singlecellexperiment components for multiplexed libraries>` section.
 
 The [metadata file](#metadata) for multiplexed libraries (`single_cell_metadata.tsv`) will have the same format as for individual samples, but each row will represent a particular sample/library pair, meaning that there may be multiple rows for each `scpca_library_id`, one for each `scpca_sample_id` within that library.
-In addition, the `demux_sample_cell_estimate` column will contain an estimate of the number of cells from the sample in the library (after demultiplexing) in the sample/library pair.
+In addition, the `demux_cell_count_estimate` column will contain an estimate of the number of cells from the sample in the library (after demultiplexing) in the sample/library pair.
 
 
 ## Merged object downloads


### PR DESCRIPTION
Addresses #367 

My plan – as described in https://github.com/AlexsLemonade/scpca-docs/issues/367#issuecomment-2478895224 – is to merge `development` -> `main` after this and cut a new release. I don't believe a CHANGELOG entry is required, as this is correcting documentation about the current downloadable files.