### PR TITLE
Update downloadable files section and 2024.08.13 CHANGELOG entry to reflect bulk filenames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,8 @@ Please see the {ref}`FAQ <faq:What does the Copy Download Link button do?>` for 
 * Downloads now follow a new naming convention: `{identifier}_{modality}_{file format}_{date}.zip`
   * For example, a sample (`SCPCS999990`) downloaded on 2024-08-13 in AnnData format will be named: `SCPCP999990_SINGLE-CELL_ANN-DATA_2024-08-13.zip`
   * See the {ref}`Downloadable files page <download_files:downloadable files>` for more information.
+* Bulk RNA-seq files now follow a new naming convention: `{project accession identifier}_bulk_quant.tsv` and `{project accession identifier}_bulk_metatdata.tsv`.
+See the {ref}`Downloadable files page <download_files:downloadable files>` for more information.
 
 ## 2024.08.01
 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -26,9 +26,9 @@ Every download also includes a single `single_cell_metadata.tsv` file containing
 Metadata-only downloads are also available, either by downloading the metadata for all samples in a single project or by downloading the metadata for all samples on the Portal.
 Please see the [section on metadata](#metadata) for a full description of the contents of the metadata files.
 
-If downloading a project containing bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the project download.
-The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
-The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
+If downloading a project containing bulk RNA-seq data, two tab-separated value files, e.g., `SCPCP000000_bulk_quant.tsv` and `SCPCP000000_bulk_metadata.tsv`, will be included in the merged object download.
+The `SCPCP000000_bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `SCPCP000000_bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
 
 See also {ref}`processing bulk RNA samples <processing_information:Bulk RNA samples>`.
 
@@ -154,7 +154,7 @@ Metadata pertaining to processing will be available in this table and inside of 
 See the {ref}`SingleCellExperiment experiment metadata <sce_file_contents:singlecellexperiment experiment metadata>` section for more information on metadata columns that can be found in the `SingleCellExperiment` object.
 See the {ref}`AnnData experiment metadata <sce_file_contents:anndata experiment metadata>` section for more information on metadata columns that can be found in the `AnnData` object.
 
-For projects with bulk RNA-seq data, the `bulk_metadata.tsv` file will be included for project downloads.
+For projects with bulk RNA-seq data, a bulk metadata file (e.g., `SCPCP000000_bulk_metadata.tsv`) will be included for project downloads.
 This file will contain fields equivalent to those found in the `single_cell_metadata.tsv` related to processing the sample, but will not contain patient or disease specific metadata (e.g. `age`, `sex`, `diagnosis`, `subdiagnosis`, `tissue_location`, or `disease_timing`).
 
 ### Metadata-only downloads
@@ -202,9 +202,9 @@ However, for `AnnData` objects, (`.h5ad` files), the quantified CITE-seq express
 Every download also includes a single `single_cell_metadata.tsv` file containing metadata for all libraries included in the merged object.
 For a full description of this file's contents, refer to the [metadata section above](#metadata).
 
-If downloading a project containing bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the merged object download.
-The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
-The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
+If downloading a project containing bulk RNA-seq data, two tab-separated value files, e.g., `SCPCP000000_bulk_quant.tsv` and `SCPCP000000_bulk_metadata.tsv`, will be included in the merged object download.
+The `SCPCP000000_bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `SCPCP000000_bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
 This file will contain fields equivalent to those found in the `single_cell_metadata.tsv` related to processing the sample, but will not contain patient or disease specific metadata (e.g. `age`, `sex`, `diagnosis`, `subdiagnosis`, `tissue_location`, or `disease_timing`).
 
 Every download includes a summary report, `SCPCL000000_merged-summary-report.html`, which provides a brief summary of the samples and libraries included in the merged object.


### PR DESCRIPTION
Stacked on #373 

Here, I'm updating the three instances where we discuss bulk files in the downloadable files section. I tried to be consistent with how we discuss accession identifiers in filenames in that section.

I am also updating the 2024.08.13 CHANGELOG entry, as this change went into effect on 2024-07-31 per https://github.com/AlexsLemonade/scpca-docs/issues/368#issuecomment-2479528007.