### PR TITLE
Update spatial link 

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -231,7 +231,7 @@ Inside that folder will be the following folders and files:
 
 - A `raw_feature_bc_matrix` folder containing the [unfiltered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
 - A `filtered_feature_bc_matrix` folder containing the [filtered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
-- A `spatial` folder containing [images and position information](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/images)
+- A `spatial` folder containing [images and position information](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/spatial)
 - A `SCPCL000000_spaceranger-summary.html` file containing the [summary html report provided by Space Ranger](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/summary)
 - A `SCPCL000000_metadata.json` file containing library processing information.
 


### PR DESCRIPTION
Closes #377 

Just updating the link to the correct location on the 10x site describing the [`spatial`](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/spatial) output. I checked the other 10x links we have and everything else is fine. 