### PR TITLE
Add changelog entry for consensus cell types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,9 +15,9 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 ## UPDATE WITH DATE FOR RELEASE 
 
 * Consensus cell type annotations are now available in all processed `SingleCellExperiment` and `AnnData` objects and merged objects. 
-  * Annotations from `SingleR` and `CellAssign` are used to assign an ontology-aware consensus cell type label. 
+  * The labels obtained from `SingleR` and `CellAssign` are used to assign an ontology-aware consensus cell type label. 
   * See our {ref}`documentation on cell type annotation<processing_information:cell type annotation>` to learn more about how consensus cell types are assigned. 
-  * For more information on locating these cell type annotations in the downloaded objects see {ref}`the single-cell gene expression file contents page<sce_file_contents:singlecellexperiment cell metrics>` and {ref}`the merged object file contents page<merged_objects:singlecellexperiment cell metrics>`.
+  * See {ref}`the single-cell gene expression file contents page<sce_file_contents:singlecellexperiment cell metrics>` and {ref}`the merged object file contents page<merged_objects:singlecellexperiment cell metrics>` for more information on obtaining these cell type annotations from the downloaded objects .
 * All assays within a merged object are now saved as a sparse matrix (`CsparseMatrix`), whereas previously these assays were saved as a `DelayedArray`. 
 
 ## 2024.11.14

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,14 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+## UPDATE WITH DATE FOR RELEASE 
+
+* Consensus cell type annotations are now available in all processed `SingleCellExperiment` and `AnnData` objects and merged objects. 
+  * Annotations from `SingleR` and `CellAssign` are used to assign an ontology-aware consensus cell type label. 
+  * See our {ref}`documentation on cell type annotation<processing_information:cell type annotation>` to learn more about how consensus cell types are assigned. 
+  * For more information on locating these cell type annotations in the downloaded objects see {ref}`the single-cell gene expression file contents page<sce_file_contents:singlecellexperiment cell metrics>` and {ref}`the merged object file contents page<merged_objects:singlecellexperiment cell metrics>`.
+* All assays within a merged object are now saved as a sparse matrix (`CsparseMatrix`), whereas previously these assays were saved as a `DelayedArray`. 
+
 ## 2024.11.14
 
 * Recent versions of the raw count matrices in `SingleCellExperiment` and `AnnData` objects were not rounded.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 * Consensus cell type annotations are now available in all processed `SingleCellExperiment` and `AnnData` objects and merged objects. 
   * The labels obtained from `SingleR` and `CellAssign` are used to assign an ontology-aware consensus cell type label. 
   * See our {ref}`documentation on cell type annotation<processing_information:cell type annotation>` to learn more about how consensus cell types are assigned. 
-  * See {ref}`the single-cell gene expression file contents page<sce_file_contents:singlecellexperiment cell metrics>` and {ref}`the merged object file contents page<merged_objects:singlecellexperiment cell metrics>` for more information on obtaining these cell type annotations from the downloaded objects .
+  * See {ref}`the single-cell gene expression file contents page<sce_file_contents:singlecellexperiment cell metrics>` and {ref}`the merged object file contents page<merged_objects:singlecellexperiment cell metrics>` for more information on obtaining these cell type annotations from the downloaded objects.
 * All assays within a merged object are now saved as a sparse matrix (`CsparseMatrix`), whereas previously these assays were saved as a `DelayedArray`. 
 
 ## 2024.11.14


### PR DESCRIPTION
Closes #403 
⚠️ Stacked on #405 

Here I'm adding a changelog entry for the addition of the consensus cell types and mentioning the change in the merged matrix format. I mostly included links for where they can learn more about the consensus labels, but let me know if I should include more detail here. 

Note that we will need to add the date once we actually are ready to release these changes, which will be done as part of completing #404. 