### PR TITLE
Add data format and modalities sections

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -98,6 +98,7 @@ submitter
 submitters
 Tian
 transcriptome
+transcriptomic
 transcriptomics
 TSV
 UMAP

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -35,10 +35,9 @@ Use the `Download Now` button next to the project title to instantly download ge
 To download more than one project or combine samples across projects, see the section on [downloading custom datasets](#custom-datasets).
 
 For project downloads, data for all samples will be provided as either [`SingleCellExperiment` objects (`.rds` files)](https://bioconductor.org/books/3.21/OSCA.intro/the-singlecellexperiment-class.html) or [`AnnData` objects (`.h5ad` files)](https://anndata.readthedocs.io/en/latest/index.html).
-If the project contains samples with a spatial transcriptomics library, the spatial data will be provided as a separate download. 
+If the project contains samples with a spatial transcriptomics library, the spatial data will be provided as a separate download.
 See the [description of the Spatial transcriptomics output section below](#spatial-transcriptomics-libraries).
-<!--TODO: Replace STUB link--> 
-For more information on choosing a data format and modality, see the {ref}`section on download options<STUB TO DATA FORMATS SECTION>`.
+For more information on choosing a data format and modality, see the {ref}`section on download options<download_options:Download options>`.
 
 If the project contains bulk RNA-seq data, two tab-separated value files, e.g., `SCPCP000000_bulk_quant.tsv` and `SCPCP000000_bulk_metadata.tsv`, will also be included in the project download.
 The `SCPCP000000_bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by `salmon`.
@@ -100,7 +99,7 @@ Every download also includes the individual [QC report](#qc-report) and, if appl
 
 ### Metadata-only downloads
 
-The Portal-wide metadata download is a single TSV file containing the metadata for all samples with associated single-cell RNA-seq, single-nuclei RNA-seq, or spatial transcriptomics data available on the Portal. 
+The Portal-wide metadata download is a single TSV file containing the metadata for all samples with associated single-cell RNA-seq, single-nuclei RNA-seq, or spatial transcriptomics data available on the Portal.
 A table describing all columns included in the file can be found in the [metadata section below](#metadata).
 
 ### `SingleCellExperiment` downloads
@@ -118,7 +117,7 @@ A table describing all columns included in the file can be found in the [metadat
 
 If downloading a sample that contains a CITE-seq library as an `AnnData` object (`.h5ad` file), the quantified CITE-seq expression data is included as a separate file with the suffix `_adt.h5ad`.
 
-<!--TODO: 
+<!--TODO:
 spatial section to be moved here, followed by the merged objects section
 -->
 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -37,7 +37,7 @@ To download more than one project or combine samples across projects, see the se
 For project downloads, data for all samples will be provided as either [`SingleCellExperiment` objects (`.rds` files)](https://bioconductor.org/books/3.21/OSCA.intro/the-singlecellexperiment-class.html) or [`AnnData` objects (`.h5ad` files)](https://anndata.readthedocs.io/en/latest/index.html).
 If the project contains samples with a spatial transcriptomics library, the spatial data will be provided as a separate download.
 See the [description of the Spatial transcriptomics output section below](#spatial-transcriptomics-libraries).
-For more information on choosing a data format and modality, see the {ref}`section on download options<download_options:Download options>`.
+For more information on choosing a data format and modality, see the {ref}`documentation on download options<download_options:Download options>`.
 
 If the project contains bulk RNA-seq data, two tab-separated value files, e.g., `SCPCP000000_bulk_quant.tsv` and `SCPCP000000_bulk_metadata.tsv`, will also be included in the project download.
 The `SCPCP000000_bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by `salmon`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -7,7 +7,7 @@ This page describes the different options available to you when downloading Port
 
 ## Data format
 
-We provide all single-cell/nuclei expression data in both [`SingleCellExperiment` objects (`.rds` files)](#singlecellexperiment-downloads) for use in R, and as [`AnnData` objects (`.h5ad` files)](#anndata-downloads) for use in Python.
+We provide all single-cell and single-nuclei expression data in both `SingleCellExperiment` objects (`.rds` files) for use in R, and as `AnnData` objects (`.h5ad` files) for use in Python.
 You can learn more about using these object types from our FAQ sections on {ref}`using the provided RDS files<faq:How do I use the provided RDS files in R?>` and {ref}`using the provided H5AD files<faq:How do I use the provided H5AD files in Python?>`.
 
 Note that only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<downloadable_files:Custom datasets>`.
@@ -25,5 +25,3 @@ If available, CITE-seq data will be automatically included with the "Single-cell
 Only one modality can be selected at a time.
 
 If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.
-
-If spatial transcriptomics data is not available for the project, then the "Single-cell" modality will be selected automatically.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -8,6 +8,7 @@ This page describes the different options available to you when downloading Port
 ## Data format
 
 We provide all single-cell and single-nuclei expression data in both `SingleCellExperiment` objects (`.rds` files) for use in R, or as `AnnData` objects (`.h5ad` files) for use in Python.
+The default format for all samples on the Portal with single-cell and single-nuclei expression is set to `SingleCellExperiment (R)`. 
 You can learn more about using these object types from our FAQ sections on {ref}`using the provided RDS files<faq:How do I use the provided RDS files in R?>` and {ref}`using the provided H5AD files<faq:How do I use the provided H5AD files in Python?>`.
 
 Only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<download_files:Custom datasets>`.
@@ -28,6 +29,7 @@ Selecting "Spatial" will provide you with the spatial transcriptomic data only.
 This option is also available when downloading any projects that have samples with spatial transcriptomic data.
 
 You can only select a single modality at a time for each sample or project you are downloading.
-If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.
+When selecting samples that have associated bulk RNA-seq, you will have the option to include the bulk RNA-seq data in your download. 
+If downloading an entire project using the `Download Now` button, any associated bulk RNA-seq data for samples in that project will automatically be included. 
 
 For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -8,28 +8,30 @@ This page describes the different options available to you when downloading Port
 ## Data format
 
 We provide all single-cell and single-nuclei expression data in both `SingleCellExperiment` objects (`.rds` files) for use in R, or as `AnnData` objects (`.h5ad` files) for use in Python.
-The default format for all samples on the Portal with single-cell and single-nuclei expression is set to `SingleCellExperiment (R)`. 
+The default format for all samples on the Portal with single-cell and single-nuclei expression is set to `SingleCellExperiment (R)`.
 You can learn more about using these object types from our FAQ sections on {ref}`using the provided RDS files<faq:How do I use the provided RDS files in R?>` and {ref}`using the provided H5AD files<faq:How do I use the provided H5AD files in Python?>`.
 
 Only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<download_files:Custom datasets>`.
 To obtain data in both `SingleCellExperiment` and `AnnData` formats, you will need to download these file formats separately.
 
-In addition, note that expression data for multiplexed libraries is only available in `SingleCellExperiment`  format, {ref}`as described here:<download_files:Multiplexed sample libraries>`.
+In addition, note that expression data for multiplexed libraries is only available in `SingleCellExperiment`  format, {ref}`as described here<download_files:Multiplexed sample libraries>`.
 
 ## Modalities
 
-Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, bulk RNA-seq, and spatial transcriptomics.
+Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, spatial transcriptomics, and bulk RNA-seq.
 
-By default, the "Single-cell" modality will be selected for all single-cell and single-nuclei RNA-seq samples.
-This will provide you with the gene expression data from single-cell or single-nuclei only.
-If available, this will also include CITE-seq data.
+In particular, there are two modality options that you may see when {ref}`creating a custom dataset to download<download_files:Project downloads>` or when {ref}`downloading a full project with the "Download Now" button<download_files:Project downloads>`: "Single-cell" and "Spatial."
 
-If a sample has spatial transcriptomic data, you will have the option to select either the "Single-cell" or "Spatial" modality for download.
+By default, the "Single-cell" modality will be selected for all single-cell and single-nuclei RNA-seq samples and/or projects.
+Selecting this download option will provide you with the gene expression data from single-cell or single-nuclei samples and/or projects.
+If available, CITE-seq expression data will also be included.
+
+If a sample or project has spatial transcriptomic data, you will also have the option to select the "Spatial" modality for download.
 Selecting "Spatial" will provide you with the spatial transcriptomic data only.
 This option is also available when downloading any projects that have samples with spatial transcriptomic data.
 
-You can only select a single modality at a time for each sample or project you are downloading.
-When selecting samples that have associated bulk RNA-seq, you will have the option to include the bulk RNA-seq data in your download. 
-If downloading an entire project using the `Download Now` button, any associated bulk RNA-seq data for samples in that project will automatically be included. 
+If you are creating a custom dataset for downloading including samples and/or projects with bulk RNA-seq data, you will have the option to include this data in your download as well.
+Note that the bulk RNA-seq data download will always include all samples from a given project with bulk expression, even if you are only downloading a subset of samples.
+If you are using the "Download now" button to download a full project that contains bulk RNA-seq expression, it will automatically be included with the download.
 
 For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -14,3 +14,14 @@ Note that only one data format is currently supported for a single download, inc
 To obtain data in both `SingleCellExperiment` and `AnnData` formats, you will need to download these file formats separately.
 
 In addition, note that `AnnData` files are not available for projects with multiplexed libraries all data on the Portal, {ref}`as described here:<download_files:Multiplexed sample libraries>`.
+
+## Modalities
+
+Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, bulk RNA-seq, and spatial transcriptomics.
+
+When downloading a project with spatial transcriptomics data, you will have the option to select either the "Single-cell" or "Spatial" modality.
+Selecting "Single-cell" will provide you with the single-cell/nuclei expression data only, and selecting "Spatial" will provide you with the spatial data only.
+If available, CITE-seq data will be automatically included with the "Single-cell" modality only.
+Only one modality can be selected at a time.
+
+If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -1,0 +1,16 @@
+# Download options
+
+You can obtain Portal data either by downloading a single project, creating a custom dataset with a selection of projects and/or samples, or by choosing one of the Portal-wide download options.
+For full information about the files you can download from the Portal, see {ref}`the Downloadable Files page<downloadable_files:Downloadable files>`.
+
+This page describes the different options available to you when downloading Portal data.
+
+## Data format
+
+We provide all single-cell/nuclei expression data in both [`SingleCellExperiment` objects (`.rds` files)](#singlecellexperiment-downloads) for use in R, and as [`AnnData` objects (`.h5ad` files)](#anndata-downloads) for use in Python.
+You can learn more about using these object types from our FAQ sections on {ref}`using the provided RDS files<faq:How do I use the provided RDS files in R?>` and {ref}`using the provided H5AD files<faq:How do I use the provided H5AD files in Python?>`.
+
+Note that only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<downloadable_files:Custom datasets>`.
+To obtain data in both `SingleCellExperiment` and `AnnData` formats, you will need to download these file formats separately.
+
+In addition, note that `AnnData` files are not available for projects with multiplexed libraries all data on the Portal, {ref}`as described here:<download_files:Multiplexed sample libraries>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -29,3 +29,5 @@ This option is also available when downloading any projects that have samples wi
 
 You can only select a single modality at a time for each sample or project you are downloading.
 If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.
+
+For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -19,6 +19,7 @@ In addition, note that `AnnData` files are not available for projects with multi
 
 Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, bulk RNA-seq, and spatial transcriptomics.
 
+<!-- TODO: Confirm with Deepa, will Single-cell be automatically selected if it's not a spatial project? -->
 When downloading a project with spatial transcriptomics data, you will have the option to select either the "Single-cell" or "Spatial" modality.
 Selecting "Single-cell" will provide you with the single-cell/nuclei expression data only, and selecting "Spatial" will provide you with the spatial data only.
 If available, CITE-seq data will be automatically included with the "Single-cell" modality only.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -1,7 +1,7 @@
 # Download options
 
 You can obtain Portal data either by downloading a single project, creating a custom dataset with a selection of projects and/or samples, or by choosing one of the Portal-wide download options.
-For full information about the files you can download from the Portal, see {ref}`the Downloadable Files page<downloadable_files:Downloadable files>`.
+For full information about the files you can download from the Portal, see {ref}`the Downloadable Files page<download_files:Downloadable files>`.
 
 This page describes the different options available to you when downloading Portal data.
 
@@ -10,7 +10,7 @@ This page describes the different options available to you when downloading Port
 We provide all single-cell and single-nuclei expression data in both `SingleCellExperiment` objects (`.rds` files) for use in R, or as `AnnData` objects (`.h5ad` files) for use in Python.
 You can learn more about using these object types from our FAQ sections on {ref}`using the provided RDS files<faq:How do I use the provided RDS files in R?>` and {ref}`using the provided H5AD files<faq:How do I use the provided H5AD files in Python?>`.
 
-Only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<downloadable_files:Custom datasets>`.
+Only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<download_files:Custom datasets>`.
 To obtain data in both `SingleCellExperiment` and `AnnData` formats, you will need to download these file formats separately.
 
 In addition, note that expression data for multiplexed libraries is only available in `SingleCellExperiment`  format, {ref}`as described here:<download_files:Multiplexed sample libraries>`.
@@ -24,7 +24,8 @@ This will provide you with the gene expression data from single-cell or single-n
 If available, this will also include CITE-seq data.
 
 If a sample has spatial transcriptomic data, you will have the option to select either the "Single-cell" or "Spatial" modality for download.
-This will provide you with the spatial transcriptomic data only.
+Selecting "Spatial" will provide you with the spatial transcriptomic data only.
 This option is also available when downloading any projects that have samples with spatial transcriptomic data.
 
+You can only select a single modality at a time for each sample or project you are downloading.
 If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -32,5 +32,7 @@ Selecting "Spatial" will provide you with the spatial transcriptomic data only.
 If you are creating a custom dataset that contains samples and/or projects with bulk RNA-seq data, you will have the option to include this data in your download as well.
 Note that the bulk RNA-seq expression file will always include all samples from the given project with bulk expression, even if you are only downloading a subset of that project's samples.
 If you are using the "Download now" button to download a full project that contains bulk RNA-seq expression, it will automatically be included with the download.
+<!-- TODO: Confirm if there are any Spatial considerations here we need to add:
+https://github.com/AlexsLemonade/scpca-docs/pull/413#issuecomment-2867497722 -->
 
 For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -19,10 +19,11 @@ In addition, note that `AnnData` files are not available for projects with multi
 
 Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, bulk RNA-seq, and spatial transcriptomics.
 
-<!-- TODO: Confirm with Deepa, will Single-cell be automatically selected if it's not a spatial project? -->
 When downloading a project with spatial transcriptomics data, you will have the option to select either the "Single-cell" or "Spatial" modality.
 Selecting "Single-cell" will provide you with the single-cell/nuclei expression data only, and selecting "Spatial" will provide you with the spatial data only.
 If available, CITE-seq data will be automatically included with the "Single-cell" modality only.
 Only one modality can be selected at a time.
 
 If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.
+
+If spatial transcriptomics data is not available for the project, then the "Single-cell" modality will be selected automatically.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -19,9 +19,12 @@ In addition, note that `AnnData` files are not available for projects with multi
 
 Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, bulk RNA-seq, and spatial transcriptomics.
 
-When downloading a project with spatial transcriptomics data, you will have the option to select either the "Single-cell" or "Spatial" modality.
-Selecting "Single-cell" will provide you with the single-cell/nuclei expression data only, and selecting "Spatial" will provide you with the spatial data only.
-If available, CITE-seq data will be automatically included with the "Single-cell" modality only.
-Only one modality can be selected at a time.
+By default, the "Single-cell" modality will be selected for all single-cell and single-nuclei RNA-seq samples. 
+This will provide you with the gene expression data from single-cell or single-nuclei only. 
+If available, this will also include CITE-seq data. 
+
+If a sample has spatial transcriptomic data, you will have the option to select either the "Single-cell" or "Spatial" modality for download. 
+This will provide you with the spatial transcriptomic data only. 
+This option is also available when downloading any projects that have samples with spatial transcriptomic data.
 
 If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -7,24 +7,24 @@ This page describes the different options available to you when downloading Port
 
 ## Data format
 
-We provide all single-cell and single-nuclei expression data in both `SingleCellExperiment` objects (`.rds` files) for use in R, and as `AnnData` objects (`.h5ad` files) for use in Python.
+We provide all single-cell and single-nuclei expression data in both `SingleCellExperiment` objects (`.rds` files) for use in R, or as `AnnData` objects (`.h5ad` files) for use in Python.
 You can learn more about using these object types from our FAQ sections on {ref}`using the provided RDS files<faq:How do I use the provided RDS files in R?>` and {ref}`using the provided H5AD files<faq:How do I use the provided H5AD files in Python?>`.
 
-Note that only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<downloadable_files:Custom datasets>`.
+Only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<downloadable_files:Custom datasets>`.
 To obtain data in both `SingleCellExperiment` and `AnnData` formats, you will need to download these file formats separately.
 
-In addition, note that `AnnData` files are not available for projects with multiplexed libraries all data on the Portal, {ref}`as described here:<download_files:Multiplexed sample libraries>`.
+In addition, note that expression data for multiplexed libraries is only available in `SingleCellExperiment`  format, {ref}`as described here:<download_files:Multiplexed sample libraries>`.
 
 ## Modalities
 
 Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, bulk RNA-seq, and spatial transcriptomics.
 
-By default, the "Single-cell" modality will be selected for all single-cell and single-nuclei RNA-seq samples. 
-This will provide you with the gene expression data from single-cell or single-nuclei only. 
-If available, this will also include CITE-seq data. 
+By default, the "Single-cell" modality will be selected for all single-cell and single-nuclei RNA-seq samples.
+This will provide you with the gene expression data from single-cell or single-nuclei only.
+If available, this will also include CITE-seq data.
 
-If a sample has spatial transcriptomic data, you will have the option to select either the "Single-cell" or "Spatial" modality for download. 
-This will provide you with the spatial transcriptomic data only. 
+If a sample has spatial transcriptomic data, you will have the option to select either the "Single-cell" or "Spatial" modality for download.
+This will provide you with the spatial transcriptomic data only.
 This option is also available when downloading any projects that have samples with spatial transcriptomic data.
 
 If the project also has bulk RNA-seq data, you can choose to include it in your download for either modality selection.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -20,7 +20,7 @@ In addition, note that expression data for multiplexed libraries is only availab
 
 Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, spatial transcriptomics, and bulk RNA-seq.
 
-In particular, there are two modality options that you may see when {ref}`creating a custom dataset to download<download_files:Project downloads>` or when {ref}`downloading a full project with the "Download Now" button<download_files:Project downloads>`: "Single-cell" and "Spatial."
+In particular, there are two modality options that you may see when {ref}`creating a custom dataset to download<download_files:Custom datasets>` or when {ref}`downloading a full project with the "Download Now" button<download_files:Project downloads>`: "Single-cell" and "Spatial."
 
 By default, the "Single-cell" modality will be selected for all single-cell and single-nuclei RNA-seq samples and/or projects.
 Selecting this download option will provide you with the gene expression data from single-cell or single-nuclei samples and/or projects.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -30,8 +30,8 @@ If a sample or project has spatial transcriptomic data, you will also have the o
 Selecting "Spatial" will provide you with the spatial transcriptomic data only.
 This option is also available when downloading any projects that have samples with spatial transcriptomic data.
 
-If you are creating a custom dataset for downloading including samples and/or projects with bulk RNA-seq data, you will have the option to include this data in your download as well.
-Note that the bulk RNA-seq data download will always include all samples from a given project with bulk expression, even if you are only downloading a subset of samples.
+If you are creating a custom dataset that contains samples and/or projects with bulk RNA-seq data, you will have the option to include this data in your download as well.
+Note that the bulk RNA-seq expression file will always include all samples from the given project with bulk expression, even if you are only downloading a subset of that project's samples.
 If you are using the "Download now" button to download a full project that contains bulk RNA-seq expression, it will automatically be included with the download.
 
 For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -14,7 +14,7 @@ You can learn more about using these object types from our FAQ sections on {ref}
 Only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<download_files:Custom datasets>`.
 To obtain data in both `SingleCellExperiment` and `AnnData` formats, you will need to download these file formats separately.
 
-In addition, note that expression data for multiplexed libraries is only available in `SingleCellExperiment`  format, {ref}`as described here<download_files:Multiplexed sample libraries>`.
+In addition, note that expression data for multiplexed libraries is only available in `SingleCellExperiment` format, {ref}`as described here<download_files:Multiplexed sample libraries>`.
 
 ## Modalities
 

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -28,7 +28,6 @@ If available, CITE-seq expression data will also be included.
 
 If a sample or project has spatial transcriptomic data, you will also have the option to select the "Spatial" modality for download.
 Selecting "Spatial" will provide you with the spatial transcriptomic data only.
-This option is also available when downloading any projects that have samples with spatial transcriptomic data.
 
 If you are creating a custom dataset that contains samples and/or projects with bulk RNA-seq data, you will have the option to include this data in your download as well.
 Note that the bulk RNA-seq expression file will always include all samples from the given project with bulk expression, even if you are only downloading a subset of that project's samples.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ The ScPCA Portal is a growing database of uniformly processed single-cell data f
 :maxdepth: 4
 
 processing_information
+download_options
 download_files
 sce_file_contents
 merged_objects


### PR DESCRIPTION
Closes #386 
Closes #387 

This PR initiates the `download_options.md` file with a brief introductory section, and I went ahead and wrote both the data format and modality sections. I decided to do these both at once since I felt they were highly related and it might be helpful to review these together for full context. They are fairly short either way so this shouldn't be a major lift! Let me know if there are more details that you think would be worth including here. For example, I thought at one point maybe we could say something in Data Formats about how bulk is TSV, but that also felt a bit out of scope and like a finer detail to leave out of this document so I nixed it while writing. 

As part of this, no existing FAQ or download files sections (unless we really want to link the full spatial section?) stood out to me to link for the "Modalities" section. I'd be interested in your feedback if you think there's a good link option there. Worth noting also, I confirmed with @dvenprasad the last sentence in here is true - that "Single-cell" will be automatically selected when there is no spatial.

Finally, I filled in one of the new stub links in `download_files.md`.