### PR TITLE
Add section on custom datasets

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -24,8 +24,8 @@ The files shown below will be included with each library (example shown for a li
 
 For more information on the contents of these files, see the sections on [gene expression data](#gene-expression-data), the [QC report](#qc-report), and the [cell type report](#cell-type-report).
 
-Every download also includes a single `single_cell_metadata.tsv` file containing metadata for all libraries included in the download.
-For a full description of the metadata file, refer to the [metadata section below](#metadata).
+Every download also includes sample and processing metadata for all libraries included in the download.
+For a full description of the metadata files, refer to the [metadata section below](#metadata).
 
 Metadata-only downloads are also available, either by downloading the metadata for all samples in a single project using the `Download Sample Metadata` button or by downloading the [metadata for all samples on the Portal](#metadata-only-downloads).
 
@@ -92,7 +92,37 @@ Every download also includes the individual [QC report](#qc-report) and, if appl
 
 ## Custom datasets
 
-<!--TODO: Fill in this section with information about creating and downloading custom datasets-->
+To download data for individual samples, multiple projects, or any combination of individual samples and projects, use the `Add to Dataset` button.
+The `My Dataset` button can then be used to view and download the custom dataset as a single zip file. 
+
+<!--TODO: Confirm that these are the correct names that will be used as the folder names for data format-->
+Each zip file will be named with a unique dataset ID, the chosen data format (either `SCE` or `AnnData`), and the date you accessed the data on the ScPCA Portal.
+Note that a custom dataset can only contain data in one format, [`SingleCellExperiment` objects (`.rds` files)](#custom-datasets-with-singlecellexperiment-format) or [`AnnData` objects (`.h5ad` files)](#custom-datasets-with-anndata-format) (see {ref}`Why can't I change the data format in My Dataset <faq:why can't i change the data format in my dataset>`). 
+
+Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either single-cell, spatial, or bulk). 
+Each project folder will also contain an appropriate metadata file, either `single-cell_metadata.tsv` (single-cell), `spatial_metadata.tsv` (spatial), or `bulk_metadata.tsv` (bulk). 
+See {ref}`the section describing download formats <download_options:data formats>`. 
+
+If downloading a project as a [merged object](#merged-object-downloads), the project folder will contain a `_merged` suffix. 
+
+If any samples included in your dataset contain associated CITE-seq data, the quantified CITE-seq expression data will be included alongside the gene expression data in the `SingleCellExperiment` objects (`.rds` files).
+For [`AnnData` downlaods (`.h5ad` files)](#download-folder-structure-for-individual-samples-with-cite-seq-adt-data), the quantified CITE-seq expression data is included as a separate file with the suffix `_adt.h5ad`.
+
+### Download folder structure for custom downloads:
+![custom dataset download](STUB-IMAGE){width="600"}
+
+### Custom datasets with `SingleCellExperiment` format
+
+#### Detailed folder structure for individual samples:
+![sample download folder](images/sample-download-folder.png){width="600"}
+
+### Custom datasets with `AnnData` format
+
+#### Detailed folder structure for individual samples:
+![sample download folder](images/anndata-sample-download-folder.png){width="600"}
+
+#### Download folder structure for individual samples with CITE-seq (ADT) data:
+![sample download folder](images/anndata-sample-citeseq-download-folder.png){width="600"}
 
 ## Portal-wide downloads
 
@@ -105,18 +135,7 @@ A table describing all columns included in the file can be found in the [metadat
 
 ### `SingleCellExperiment` downloads
 
-#### Download folder structure for individual sample downloads:
-![sample download folder](images/sample-download-folder.png){width="600"}
-
 ### `AnnData` downloads
-
-#### Download folder structure for individual sample downloads:
-![sample download folder](images/anndata-sample-download-folder.png){width="600"}
-
-#### Download folder structure for individual sample downloads with CITE-seq (ADT) data:
-![sample download folder](images/anndata-sample-citeseq-download-folder.png){width="600"}
-
-If downloading a sample that contains a CITE-seq library as an `AnnData` object (`.h5ad` file), the quantified CITE-seq expression data is included as a separate file with the suffix `_adt.h5ad`.
 
 <!--TODO: 
 spatial section to be moved here, followed by the merged objects section


### PR DESCRIPTION
Closes #390 

Here I'm adding the section describing the download contents of a custom dataset. I included some text describing how to create a custom dataset and then described the contents of the zip file, depending on what is included in the dataset. I also mentioned that you can only use one data format and linked to the FAQ that doesn't exist yet. 

For the actual file structures, I stubbed in an overview image that is being tracked in #381. We weren't sure yet if we wanted to have one generalized one or break it down by data format, but I think the solution is to have one generalized one and then show a zoomed in view of what a single-cell download as SCE vs. AnnData looks like. I stubbed in the images we have for sample downloads right now, but those will need to be updated to have the correct folder titles and remove the metadata/ readme etc. 

I'm requesting review from both @sjspielman and @dvenprasad since I want to be sure I'm explaining it correctly. What do we think of how I have it set up with the high-level image and then more granular images? Is there anything else missing that I should be sure to cover in this section? 

I also have a TODO about making sure we use the correct folder names for `{data-format}` since I couldn't find where the names we decided on lived. 

Side note: I made a small edit to the metadata sentences in the introduction since technically not every download includes `single_cell_metadata.tsv`. 