### PR TITLE
Add "merge options" section

### DIFF
--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -40,6 +40,7 @@ For more information about the expected file download structure for "Single-cell
 
 When downloading all single-cell or single-nuclei samples from a project, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects.md:Merged objects>`.
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
+Refer to {ref}`this documentation<download_files:Merged object downloads` for the contents of a merged object download specifically.
 
 When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from a project in `My dataset`. 
 Merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -42,7 +42,7 @@ When downloading all single-cell or single-nuclei samples from a project, you wi
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
 Refer to {ref}`this documentation<download_files:Merged object downloads` for the contents of a merged object download specifically.
 
-When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from a project in `My dataset`. 
+When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from the given project in `My dataset`.
 Merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.
 In addition, merged objects are not available for all samples or projects, {ref}`as described here<faq:Which projects can I download as merged objects?`.
 

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -41,6 +41,7 @@ For more information about the expected file download structure for "Single-cell
 When downloading a project, either by using `Download Now` or `Add to Dataset`, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects.md:Merged objects>`.
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
 Refer to {ref}`this documentation<download_files:Merged object downloads` for the contents of a merged object download specifically.
+Note that this applies only to "Single-cell" modality downloads, not "Spatial."
 
 When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from the given project in `My dataset`.
 Merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -38,7 +38,7 @@ For more information about the expected file download structure for "Single-cell
 
 ## Merge options
 
-When downloading all single-cell or single-nuclei samples from a project, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects.md:Merged objects>`.
+When downloading a project, either by using `Download Now` or `Add to Dataset`, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects.md:Merged objects>`.
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
 Refer to {ref}`this documentation<download_files:Merged object downloads` for the contents of a merged object download specifically.
 

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -41,9 +41,9 @@ For more information about the expected file download structure for "Single-cell
 When downloading all single-cell or single-nuclei samples from a project, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects.md:Merged objects>`.
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
 
-When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you are downloading all samples from a project or a full project itself.
-All samples in a given project must be included; merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.
+When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from a project in `My dataset`. 
+Merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.
 In addition, merged objects are not available for all samples or projects, {ref}`as described here<faq:Which projects can I download as merged objects?`.
 
-Note that even when {ref}`downloading the full Portal<download_files:Portal-wide downloads>`, merged objects will still be provided per-project.
+Note that even when {ref}`downloading data for all single-cell and single-nuclei samples on the Portal<download_files:Portal-wide downloads>`, merged objects will still be provided per-project.
 There will not be a merged object with all samples from all projects, but a single merged object for each project.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -35,3 +35,15 @@ Note that the bulk RNA-seq expression file will always include all samples from 
 If you are using the "Download now" button to download a full project that contains bulk RNA-seq expression, it will automatically be included with the download.
 
 For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.
+
+## Merge options
+
+When downloading all single-cell or single-nuclei samples from a project, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects.md:Merged objects>`.
+Please be aware that merged objects have _not_ been integrated or batch-corrected.
+
+When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you are downloading all samples from a project or a full project itself.
+All samples in a given project must be included; merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.
+In addition, merged objects are not available for all samples or projects, {ref}`as described here<faq:Which projects can I download as merged objects?`.
+
+Note that even when {ref}`downloading the full Portal<download_files:Portal-wide downloads>`, merged objects will still be provided per-project.
+There will not be a merged object with all samples from all projects, but a single merged object for each project.


### PR DESCRIPTION
Closes #388
**(Edit) Stacked on #413**

This PR adds a section for merged objects. I first state that merged objects are available when all samples are downloaded, link out to the merged docs, and remind everyone that we don't integrate. Then, I describe how this works for "My Dataset". Finally, I note that the full portal download, when merged, is not _all merged_ but still merged per-project.

Something I think might be missing is an explicit statement about "Download Now," but I felt that that comes across when describing what happens when you download all samples for a project well enough. Please let me know if you disagree and something more explicit would be helpful!