### PR TITLE
Add section on multiplexed options

### DIFF
--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -37,7 +37,7 @@ https://github.com/AlexsLemonade/scpca-docs/pull/413#issuecomment-2867497722 -->
 
 For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.
 
-## Merge options
+## Merged objects
 
 When downloading a project, either by using `Download Now` or `Add to Dataset`, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects:Merged objects>`.
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
@@ -53,7 +53,7 @@ There will not be a merged object with all samples from all projects, but a sing
 
 ## Multiplexed sample libraries
 
-When downloading a project that contains multiplexed samples (see {ref}`what is a multiplexed sample? <faq:What is a multiplexed sample?>`, you will have the option to exclude multiplexed samples from the download.
+When downloading a project that contains multiplexed samples (see {ref}`what is a multiplexed sample? <faq:What is a multiplexed sample?>`), you will have the option to exclude multiplexed samples from the download.
 If selected, the download will contain expression data for only non-multiplexed samples.
 Note that, {ref}`as described in our FAQ<faq:Which samples can I download as AnnData objects?>`, `AnnData`-formatted files are not available for multiplexed samples.
 In addition, you will not be able to select the option to merge samples into a single file {ref}`if the project contains multiplexed samples<faq:Which projects can I download as merged objects?>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -51,9 +51,9 @@ In addition, merged objects are not available for all samples or projects, {ref}
 Note that even when {ref}`downloading data for all single-cell and single-nuclei samples on the Portal<download_files:Portal-wide downloads>`, merged objects will still be provided per-project.
 There will not be a merged object with all samples from all projects, but a single merged object for each project.
 
-## Multiplexed objects
+## Multiplexed sample libraries
 
-When downloading a project that contains multiplexed samples, you will have the option to exclude multiplexed samples from the download.
-If selected, the download will contain expression data for only non-multiplexed libraries.
+When downloading a project that contains multiplexed samples (see {ref}`what is a multiplexed sample? <faq:What is a multiplexed sample?>`, you will have the option to exclude multiplexed samples from the download.
+If selected, the download will contain expression data for only non-multiplexed samples.
 Note that, {ref}`as described in our FAQ<faq:Which samples can I download as AnnData objects?>`, `AnnData`-formatted files are not available for multiplexed samples.
 In addition, you will not be able to select the option to merge samples into a single file {ref}`if the project contains multiplexed samples<faq:Which projects can I download as merged objects?>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -53,7 +53,7 @@ There will not be a merged object with all samples from all projects, but a sing
 
 ## Multiplexed sample libraries
 
-When downloading a project that contains multiplexed samples (see {ref}`what is a multiplexed sample? <faq:What is a multiplexed sample?>`), you will have the option to exclude multiplexed samples from the download.
+When downloading a project that contains multiplexed samples (see {ref}`What is a multiplexed sample? <faq:What is a multiplexed sample?>`), you will have the option to exclude multiplexed samples from the download.
 If selected, the download will contain expression data for only non-multiplexed samples.
 Note that, {ref}`as described in our FAQ<faq:Which samples can I download as AnnData objects?>`, `AnnData`-formatted files are not available for multiplexed samples.
 In addition, you will not be able to select the option to merge samples into a single file {ref}`if the project contains multiplexed samples<faq:Which projects can I download as merged objects?>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -55,5 +55,5 @@ There will not be a merged object with all samples from all projects, but a sing
 
 When downloading a project that contains multiplexed samples (see {ref}`What is a multiplexed sample? <faq:What is a multiplexed sample?>`), you will have the option to exclude multiplexed samples from the download.
 If selected, the download will contain expression data for only non-multiplexed samples.
-Note that, {ref}`as described in our FAQ<faq:Which samples can I download as AnnData objects?>`, `AnnData`-formatted files are not available for multiplexed samples.
+Note that, {ref}`as described in our FAQ<faq:Which samples can I download as AnnData objects?>`, `AnnData` objects (`.h5ad` files) are not available for multiplexed samples.
 In addition, you will not be able to select the option to merge samples into a single file {ref}`if the project contains multiplexed samples<faq:Which projects can I download as merged objects?>`.

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -50,3 +50,10 @@ In addition, merged objects are not available for all samples or projects, {ref}
 
 Note that even when {ref}`downloading data for all single-cell and single-nuclei samples on the Portal<download_files:Portal-wide downloads>`, merged objects will still be provided per-project.
 There will not be a merged object with all samples from all projects, but a single merged object for each project.
+
+## Multiplexed objects
+
+When downloading a project that contains multiplexed samples, you will have the option to exclude multiplexed samples from the download.
+If selected, the download will contain expression data for only non-multiplexed libraries.
+Note that, {ref}`as described in our FAQ<faq:Which samples can I download as AnnData objects?>`, `AnnData`-formatted files are not available for multiplexed samples.
+In addition, you will not be able to select the option to merge samples into a single file {ref}`if the project contains multiplexed samples<faq:Which projects can I download as merged objects?>`.


### PR DESCRIPTION
Closes #389 

This PR adds a section stating that multiplexed samples can be optionally excluded from project downloads. I linked a couple other spots in documentation with some more caveats related to multiplexed data downloads/files as well. It's pretty short but I think this pretty much covers it? Please let me know what other details you think I might be missing here!