### PR TITLE
Update remaining sections of download files

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -101,8 +101,8 @@ Each zip file will be named with a unique dataset ID, the chosen data format (ei
 Note that a custom dataset can only contain data in one format, [`SingleCellExperiment` objects (`.rds` files)](#custom-datasets-with-singlecellexperiment-format) or [`AnnData` objects (`.h5ad` files)](#custom-datasets-with-anndata-format) (see {ref}`FAQ for more information<faq:Why can't I change the data format in My Dataset?>`). 
 If a sample has [spatial transcriptomics data](#spatial-transcriptomics-libraries), you can check the {ref}`Spatial modality box<download_options:Modalities>` to include the spatial transcriptomics data in `My Dataset`.
 
-Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either `Single-cell`, `Spatial`, or `Bulk`). 
-Each project folder will also contain an appropriate metadata file, either `single-cell_metadata.tsv` (`Single-cell`), `spatial_metadata.tsv` (`Spatial`), or `SCPCP000000_bulk_metadata.tsv` (`Bulk`). 
+Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either `single-cell`, `spatial`, or `bulk`). 
+Each project folder will also contain an appropriate metadata file, either `single-cell_metadata.tsv` (`single-cell`), `spatial_metadata.tsv` (`spatial`), or `SCPCP000000_bulk_metadata.tsv` (`bulk`). 
 For more information on available data formats and modalities, see {ref}`the section describing download options <download_options:data formats>`. 
 
 If downloading a project as a [merged object](#merged-object-downloads), the project folder will contain a `_merged` suffix. 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -97,7 +97,7 @@ The `My Dataset` button can be used to view and download the custom dataset as a
 
 <!--TODO: Confirm that these are the correct names that will be used as the folder names for data format-->
 Each zip file will be named with a unique dataset ID, the chosen data format (either `SingleCellExperiment` or `AnnData`), and the date you accessed the data on the ScPCA Portal.
-Note that a custom dataset can only contain data in one format, [`SingleCellExperiment` objects (`.rds` files)](#custom-datasets-with-singlecellexperiment-format) or [`AnnData` objects (`.h5ad` files)](#custom-datasets-with-anndata-format) (see {ref}`Why can't I change the data format in My Dataset <faq:why can't i change the data format in my dataset>`). 
+Note that a custom dataset can only contain data in one format, [`SingleCellExperiment` objects (`.rds` files)](#custom-datasets-with-singlecellexperiment-format) or [`AnnData` objects (`.h5ad` files)](#custom-datasets-with-anndata-format) (see {ref}`FAQ for more information<faq:Why can't I change the data format in My Dataset?>`). 
 If a sample has [spatial transcriptomics data](#spatial-transcriptomics-libraries), the `Spatial` box can be used to indicate whether or not to include the spatial transcriptomics data in the download. 
 
 Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either single-cell, spatial, or bulk). 
@@ -151,7 +151,7 @@ For [`AnnData (Python)` downloads](#anndata-portal-wide-download-structure), the
 ![portal wide download structure - `anndata`](STUB-IMAGE){width="600"}
 
 ### Spatial Portal-wide download structure
-![portal wide download structure - spatial](#STUB-IMAE){width="600"}
+![portal wide download structure - spatial](#STUB-IMAGE){width="600"}
 
 ### Portal-wide downloads as merged objects
 
@@ -294,7 +294,7 @@ In addition, the `demux_cell_count_estimate` column will contain an estimate of 
 
 ## Spatial transcriptomics libraries
 
-If a sample includes a library processed using spatial transcriptomics, the spatial transcriptomics output files will be available as a separate download from the single-cell/single-nuclei gene expression data by selecting "Spatial" as the modality (see more on {ref}`modalities <download_options:modalities>`). 
+If a sample includes a library processed using spatial transcriptomics, you can obtain the spatial transcriptomics output files as a separate download from the single-cell/single-nuclei gene expression data by selecting "Spatial" as the modality (see more on {ref}`modality download options<download_options:modalities>`). 
 
 For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download.
 Inside that folder will be the following folders and files:
@@ -307,6 +307,7 @@ Inside that folder will be the following folders and files:
 
 A full description of all files included in the download for spatial transcriptomics libraries can also be found in the [`spaceranger count` documentation](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/using/count#outputs).
 
+<!-- TODO: Confirm spatial_metadata.tsv or spatial-metadata.tsv: https://github.com/AlexsLemonade/scpca-docs/issues/381#issuecomment-2867277605 -->
 Every download also includes a single `spatial_metadata.tsv` file containing metadata for all libraries included in the download.
 
 <!--TODO: update this image to have correct folder names-->

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -100,8 +100,8 @@ Each zip file will be named with a unique dataset ID, the chosen data format (ei
 Note that a custom dataset can only contain data in one format, [`SingleCellExperiment` objects (`.rds` files)](#custom-datasets-with-singlecellexperiment-format) or [`AnnData` objects (`.h5ad` files)](#custom-datasets-with-anndata-format) (see {ref}`FAQ for more information<faq:Why can't I change the data format in My Dataset?>`). 
 If a sample has [spatial transcriptomics data](#spatial-transcriptomics-libraries), you can check the {ref}`Spatial modality box<download_options:Modalities>` to include the spatial transcriptomics data in `My Dataset`.
 
-Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either single-cell, spatial, or bulk). 
-Each project folder will also contain an appropriate metadata file, either `single-cell_metadata.tsv` (single-cell), `spatial_metadata.tsv` (spatial), or `SCPCP000000_bulk_metadata.tsv` (bulk). 
+Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either `Single-cell`, `Spatial`, or `Bulk`). 
+Each project folder will also contain an appropriate metadata file, either `single-cell_metadata.tsv` (`Single-cell`), `spatial_metadata.tsv` (`Spatial`), or `SCPCP000000_bulk_metadata.tsv` (`Bulk`). 
 For more information on available data formats and modalities, see {ref}`the section describing download options <download_options:data formats>`. 
 
 If downloading a project as a [merged object](#merged-object-downloads), the project folder will contain a `_merged` suffix. 
@@ -294,7 +294,7 @@ In addition, the `demux_cell_count_estimate` column will contain an estimate of 
 
 ## Spatial transcriptomics libraries
 
-If a sample includes a library processed using spatial transcriptomics, you can obtain the spatial transcriptomics output files by selecting "Spatial" as the modality (see more on {ref}`modality download options<download_options:modalities>`). 
+If a sample includes a library processed using spatial transcriptomics, you can obtain the spatial transcriptomics output files by selecting `Spatial` as the modality (see more on {ref}`modality download options<download_options:modalities>`). 
 
 If downloading an [entire project using the `Download Now` button](#project-downloads), you will need to download the spatial data separately from the single-cell and single-nuclei gene expression data. 
 If creating and downloading a [custom dataset by using the `Add to Dataset` button](#custom-datasets), you will be able to select both `Single-cell` and `Spatial` to be included in the download. 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -7,7 +7,7 @@ When you uncompress the zip file, the root directory name of your download will 
 We recommend you record this date in case there are future updates to the Portal that change the underlying data or if you need to cite the data in the future (see {ref}`How to Cite <citation:how to cite>` for more information).
 Please see our {ref}`CHANGELOG <CHANGELOG:CHANGELOG>` for a summary of changes that impact downloads from the Portal.
 
-Data can be downloaded by either downloading a [single project](#project-downloads), creating a [custom dataset](#custom-datasets), or by choosing one of the [portal-wide download options](#portal-wide-downloads).
+Data can be downloaded by either downloading a [single project](#project-downloads), creating a [custom dataset](#custom-datasets), or by choosing one of the [Portal-wide download options](#portal-wide-downloads).
 For all data downloads, sample folders (indicated by the `SCPCS` prefix) contain the files for all libraries (`SCPCL` prefix) derived from that biological sample.
 Most samples only have one library that has been sequenced.
 For [multiplexed sample libraries](#multiplexed-sample-libraries), the sample folder name will be an underscore-separated list of all samples found in the library files that the folder contains.
@@ -98,6 +98,7 @@ The `My Dataset` button can be used to view and download the custom dataset as a
 <!--TODO: Confirm that these are the correct names that will be used as the folder names for data format-->
 Each zip file will be named with a unique dataset ID, the chosen data format (either `SingleCellExperiment` or `AnnData`), and the date you accessed the data on the ScPCA Portal.
 Note that a custom dataset can only contain data in one format, [`SingleCellExperiment` objects (`.rds` files)](#custom-datasets-with-singlecellexperiment-format) or [`AnnData` objects (`.h5ad` files)](#custom-datasets-with-anndata-format) (see {ref}`Why can't I change the data format in My Dataset <faq:why can't i change the data format in my dataset>`). 
+If a sample has [spatial transcriptomics data](#spatial-transcriptomics-libraries), the `Spatial` box can be used to indicate whether or not to include the spatial transcriptomics data in the download. 
 
 Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either single-cell, spatial, or bulk). 
 Each project folder will also contain an appropriate metadata file, either `single-cell_metadata.tsv` (single-cell), `spatial_metadata.tsv` (spatial), or `SCPCP000000_bulk_metadata.tsv` (bulk). 
@@ -149,9 +150,8 @@ For [`AnnData (Python)` downloads](#anndata-portal-wide-download-structure), the
 ### `AnnData` Portal-wide download structure
 ![portal wide download structure - `anndata`](STUB-IMAGE){width="600"}
 
-<!--TODO:
-spatial section to be moved here
--->
+### Spatial Portal-wide download structure
+![portal wide download structure - spatial](#STUB-IMAE){width="600"}
 
 ### Portal-wide downloads as merged objects
 
@@ -277,10 +277,11 @@ This file will contain fields equivalent to those found in the `single_cell_meta
 For libraries where multiple biological samples were combined via cellhashing or similar technology (see the {ref}`FAQ section about multiplexed samples <faq:What is a multiplexed sample?>`), the organization of the downloaded files and metadata is slightly different.
 Note that multiplexed sample libraries are only available as `SingleCellExperiment` objects, and are not currently available as `AnnData` objects.
 
-For project downloads, the counts and QC files will be organized by the _set_ of samples that comprise each library, rather than in individual sample folders.
+When downloading an entire project, the counts and QC files will be organized by the _set_ of samples that comprise each library, rather than in individual sample folders.
 These sample set folders are named with an underscore-separated list of the sample ids for the libraries within, _e.g._, `SCPCS999990_SCPCS999991_SCPCS999992`.
-Bulk RNA-seq data, if present, will follow the [same format as bulk RNA-seq for single-sample libraries](#download-folder-structure-for-project-downloads).
+Bulk RNA-seq data, if present, will follow the [same format as bulk RNA-seq for single-sample libraries](#download-folder-structure-for-singlecellexperiment-project-downloads).
 
+<!--TODO: update this image to have correct folder names-->
 ![multiplexed project download folder](images/multiplexed-download-folder.png){width="750"}
 
 Because we do not perform demultiplexing to separate cells from multiplexed libraries into sample-specific count matrices, sample downloads from a project with multiplexed data will include all libraries that contain the sample of interest, but these libraries _will still contain cells from other samples_.
@@ -293,7 +294,7 @@ In addition, the `demux_cell_count_estimate` column will contain an estimate of 
 
 ## Spatial transcriptomics libraries
 
-If a sample includes a library processed using spatial transcriptomics, the spatial transcriptomics output files will be available as a separate download from the single-cell/single-nuclei gene expression data.
+If a sample includes a library processed using spatial transcriptomics, the spatial transcriptomics output files will be available as a separate download from the single-cell/single-nuclei gene expression data by selecting "Spatial" as the modality (see more on {ref}`modalities <download_options:modalities>`). 
 
 For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download.
 Inside that folder will be the following folders and files:
@@ -308,4 +309,5 @@ A full description of all files included in the download for spatial transcripto
 
 Every download also includes a single `spatial_metadata.tsv` file containing metadata for all libraries included in the download.
 
+<!--TODO: update this image to have correct folder names-->
 ![sample download with spatial](images/spatial-download-folder.png){width="600"}

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -98,7 +98,7 @@ The `My Dataset` button can be used to view and download the custom dataset as a
 <!--TODO: Confirm that these are the correct names that will be used as the folder names for data format-->
 Each zip file will be named with a unique dataset ID, the chosen data format (either `SingleCellExperiment` or `AnnData`), and the date you accessed the data on the ScPCA Portal.
 Note that a custom dataset can only contain data in one format, [`SingleCellExperiment` objects (`.rds` files)](#custom-datasets-with-singlecellexperiment-format) or [`AnnData` objects (`.h5ad` files)](#custom-datasets-with-anndata-format) (see {ref}`FAQ for more information<faq:Why can't I change the data format in My Dataset?>`). 
-If a sample has [spatial transcriptomics data](#spatial-transcriptomics-libraries), the `Spatial` box can be used to indicate whether or not to include the spatial transcriptomics data in the download. 
+If a sample has [spatial transcriptomics data](#spatial-transcriptomics-libraries), you can check the {ref}`Spatial modality box<download_options:Modalities>` to include the spatial transcriptomics data in `My Dataset`.
 
 Data for all samples included in `My Dataset` will be organized in folders labeled with the unique project identifier and modality, where each folder contains data for all samples from a single project with the same modality (either single-cell, spatial, or bulk). 
 Each project folder will also contain an appropriate metadata file, either `single-cell_metadata.tsv` (single-cell), `spatial_metadata.tsv` (spatial), or `SCPCP000000_bulk_metadata.tsv` (bulk). 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -294,7 +294,11 @@ In addition, the `demux_cell_count_estimate` column will contain an estimate of 
 
 ## Spatial transcriptomics libraries
 
-If a sample includes a library processed using spatial transcriptomics, you can obtain the spatial transcriptomics output files as a separate download from the single-cell/single-nuclei gene expression data by selecting "Spatial" as the modality (see more on {ref}`modality download options<download_options:modalities>`). 
+If a sample includes a library processed using spatial transcriptomics, you can obtain the spatial transcriptomics output files by selecting "Spatial" as the modality (see more on {ref}`modality download options<download_options:modalities>`). 
+
+If downloading an [entire project using the `Download Now` button](#project-downloads), you will need to download the spatial data separately from the single-cell and single-nuclei gene expression data. 
+If creating and downloading a [custom dataset by using the `Add to Dataset` button](#custom-datasets), you will be able to select both `Single-cell` and `Spatial` to be included in the download. 
+Alternatively, you can download all of the spatial transcriptomic data from the Portal on the [Portal-wide Downloads page](#portal-wide-downloads).
 
 For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download.
 Inside that folder will be the following folders and files:

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -131,7 +131,7 @@ For [`AnnData` objects (`.h5ad` files)](#detailed-folder-structure-for-individua
 The Portal-wide Download page can be used to download all [metadata](#metadata-only-downloads) or gene expression data for all samples on the Portal at once. 
 
 All single-cell and single-nuclei gene expression data from the Portal can be downloaded as a single zip file containing data stored as either [`SingleCellExperiment` objects (`.rds` files)](#singlecellexperiment-portal-wide-download-structure) or [`AnnData` objects (`.h5ad` files)](#anndata-portal-wide-download-structure). 
-All spatial data for any samples sequenced using [spatial transcriptomics](#spatial-transcriptomics-libraries) is available separately as a zip file. 
+All spatial data for any samples sequenced using [spatial transcriptomics](#spatial-transcriptomics-libraries) are available separately as a zip file. 
 
 When downloading any of the available Portal-wide data downloads, all metadata and bulk RNA-seq data is also included. 
 

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -20,14 +20,14 @@ In addition, note that expression data for multiplexed libraries is only availab
 
 Besides single-cell/nuclei expression, many samples in the Portal have additional sequencing modalities including CITE-seq, spatial transcriptomics, and bulk RNA-seq.
 
-In particular, there are two modality options that you may see when {ref}`creating a custom dataset to download<download_files:Custom datasets>` or when {ref}`downloading a full project with the "Download Now" button<download_files:Project downloads>`: "Single-cell" and "Spatial."
+In particular, there are two modality options that you may see when {ref}`creating a custom dataset to download<download_files:Custom datasets>` or when {ref}`downloading a full project with the "Download Now" button<download_files:Project downloads>`: `Single-cell` and `Spatial`.
 
-By default, the "Single-cell" modality will be selected for all single-cell and single-nuclei RNA-seq samples and/or projects.
+By default, the `Single-cell` modality will be selected for all single-cell and single-nuclei RNA-seq samples and/or projects.
 Selecting this download option will provide you with the gene expression data from single-cell or single-nuclei samples and/or projects.
 If available, CITE-seq expression data will also be included.
 
-If a sample or project has spatial transcriptomic data, you will also have the option to select the "Spatial" modality for download.
-Selecting "Spatial" will provide you with the spatial transcriptomic data only.
+If a sample or project has spatial transcriptomic data, you will also have the option to select the `Spatial` modality for download.
+Selecting `Spatial` will provide you with the spatial transcriptomic data only.
 
 If you are creating a custom dataset that contains samples and/or projects with bulk RNA-seq data, you will have the option to include this data in your download as well.
 Note that the bulk RNA-seq expression file will always include all samples from the given project with bulk expression, even if you are only downloading a subset of that project's samples.
@@ -35,14 +35,14 @@ If you are using the "Download now" button to download a full project that conta
 <!-- TODO: Confirm if there are any Spatial considerations here we need to add:
 https://github.com/AlexsLemonade/scpca-docs/pull/413#issuecomment-2867497722 -->
 
-For more information about the expected file download structure for "Single-cell" and "Spatial" modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.
+For more information about the expected file download structure for `Single-cell` and `Spatial` modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.
 
 ## Merge options
 
 When downloading a project, either by using `Download Now` or `Add to Dataset`, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects:Merged objects>`.
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
 Refer to {ref}`this documentation<download_files:Merged object downloads` for the contents of a merged object download specifically.
-Note that this applies only to "Single-cell" modality downloads, not "Spatial."
+Note that this applies only to `Single-cell` modality downloads, not `Spatial`.
 
 When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from the given project in `My dataset`.
 Merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.


### PR DESCRIPTION
⚠️ Stacked on #414 
Closes #395 
Closes #397 

Here I'm making some minor changes to make sure we account for spatial options throughout the download files section. These were pretty minimal since we already had a detailed spatial section outlining what's included with a spatial library. I mostly added in sentences that linked to that section when necessary and then added one more image for the spatial Portal-wide download structure. 

Once this goes in then I believe that should be everything for text changes to the Download files section and all that will be left to do is update all the images and fix any TODOs. 
