### PR TITLE
Add FAQ: one format at a time

### DIFF
--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -44,7 +44,7 @@ Please be aware that merged objects have _not_ been integrated or batch-correcte
 Refer to {ref}`this documentation<download_files:Merged object downloads` for the contents of a merged object download specifically.
 Note that this applies only to "Single-cell" modality downloads, not "Spatial."
 
-When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from the given project in `My dataset`.
+When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from the given project in `My Dataset`.
 Merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.
 In addition, merged objects are not available for all samples or projects, {ref}`as described here <faq:Which projects can I download as merged objects?>`.
 

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -11,7 +11,7 @@ We provide all single-cell and single-nuclei expression data in both `SingleCell
 The default format for all samples on the Portal with single-cell and single-nuclei expression is set to `SingleCellExperiment (R)`.
 You can learn more about using these object types from our FAQ sections on {ref}`using the provided RDS files<faq:How do I use the provided RDS files in R?>` and {ref}`using the provided H5AD files<faq:How do I use the provided H5AD files in Python?>`.
 
-Only one data format is currently supported for a single download, including when {ref}`downloading custom datasets<download_files:Custom datasets>`.
+Only {ref}`one data format is currently supported for a single download<faq:Why can't I change the data format in My Dataset?>`, including when {ref}`downloading custom datasets<download_files:Custom datasets>`.
 To obtain data in both `SingleCellExperiment` and `AnnData` formats, you will need to download these file formats separately.
 
 In addition, note that expression data for multiplexed libraries is only available in `SingleCellExperiment` format, {ref}`as described here<download_files:Multiplexed sample libraries>`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -245,6 +245,6 @@ Download links are only available for projects (i.e., not for downloading indivi
 
 When creating a {ref}`custom dataset for download<download_files:Custom datasets>` (`My Dataset`), all single-cell sample or project data included must be of the same {ref}`data format<download_options:Data format>`, either `SingleCellExperiment` for use in R or `AnnData` for use in Python.
 We currently do not support including both data formats at once in `My Dataset`.
-Once a sample or project of a given data format has been added to `My Dataset`, all subsequent single-cell data added will automatically be in that same format.
+Once a sample or project of a given data format has been added to `My Dataset`, all subsequent single-cell or single-nuclei data added will automatically be in that same format.
 
-Therefore, if you wish to download single-cell expression data in both `SingleCellExperiment` and `AnnData` data formats, you will need to create and download separate `My Dataset`s, one at a time, for each format.
+Therefore, if you wish to download single-cell or single-nuclei expression data in both `SingleCellExperiment` and `AnnData` data formats, you will need to create and download separate `My Dataset`s, one at a time, for each format.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -247,4 +247,4 @@ When creating a {ref}`custom dataset for download<download_files:Custom datasets
 We currently do not support including both data formats at once in `My Dataset`.
 Once a sample or project of a given data format has been added to `My Dataset`, all subsequent single-cell data added will automatically be in that same format.
 
-Therefore, if you wish to download single-cell expression data in both `SingleCEllExperiment` and `AnnData` data formats, you will need to create and download separate `My Dataset`s, one at a time, for each format.
+Therefore, if you wish to download single-cell expression data in both `SingleCellExperiment` and `AnnData` data formats, you will need to create and download separate `My Dataset`s, one at a time, for each format.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -243,7 +243,7 @@ Download links are only available for projects (i.e., not for downloading indivi
 
 ## Why can't I change the data format in My Dataset?
 
-When creating a `{ref}custom dataset for download<download_files:Custom datasets>` (`My Dataset`), all single-cell sample or project data included must be of the same `{ref}data format<download_options:Data format>`, either `SingleCellExperiment` for use in R or `AnnData` for use in Python.
+When creating a {ref}`custom dataset for download<download_files:Custom datasets>` (`My Dataset`), all single-cell sample or project data included must be of the same {ref}`data format<download_options:Data format>`, either `SingleCellExperiment` for use in R or `AnnData` for use in Python.
 We currently do not support including both data formats at once in `My Dataset`.
 Once a sample or project of a given data format has been added to `My Dataset`, all subsequent single-cell data added will automatically be in that same format.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -234,10 +234,17 @@ However, we respect submitters' requests to remove samples if they have deemed t
 
 ## What does the Copy Download Link button do?
 
-The copy download link allows you to copy the URL to download a project using a command line tool such as [`wget`](https://www.gnu.org/software/wget/) or [`curl`](https://curl.se/). 
+The copy download link allows you to copy the URL to download a project using a command line tool such as [`wget`](https://www.gnu.org/software/wget/) or [`curl`](https://curl.se/).
 It does not trigger a download via your web browser, so you must take additional steps to download the data with another tool.
 
 Download links expire in 7 days, but you can generate a new link on the ScPCA Portal as often as needed.
 
 Download links are only available for projects (i.e., not for downloading individual samples).
 
+## Why can't I change the data format in My Dataset?
+
+When creating a `{ref}custom dataset for download<download_files:Custom datasets>` (`My Dataset`), all single-cell sample or project data included must be of the same `{ref}data format<download_options:Data format>`, either `SingleCellExperiment` for use in R or `AnnData` for use in Python.
+We currently do not support including both data formats at once in `My Dataset`.
+Once a sample or project of a given data format has been added to `My Dataset`, all subsequent single-cell data added will automatically be in that same format.
+
+Therefore, if you wish to download single-cell expression data in both `SingleCEllExperiment` and `AnnData` data formats, you will need to create and download separate `My Dataset`s, one at a time, for each format.


### PR DESCRIPTION
Closes #398 

This PR adds an FAQ explaining that only one data format is available at a time. I also link this FAQ in the data format section of `download_options`. The issue here also suggested stating that you can empty or download your cart if you want to make a new one, but I didn't include that specific detail since it seemed to me to be well-captured by the concept "you need to do two carts to get both formats." Let me know if you disagree and we should indeed be more explicit!

Edit: As noted in the issue since this wasn't slated for this sprint, we can wait to review until next sprint if you prefer!