### PR TITLE
Add section that you can't merge sample subsets

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -200,7 +200,7 @@ The samples have simply been merged into a single file - _they have not been int
 
 You may prefer to download this merged object instead of individual sample files to facilitate downstream analyses that consider multiple samples at once, such as differential expression analysis, integrating multiple samples, or jointly clustering multiple samples.
 
-Please refer to {ref}`the getting started with a merged object section<getting_started:Working with a Merged ScPCA object>` for more details on working with merged objects.
+Please refer to {ref}`the section about getting started with a merged object<getting_started:Working with a Merged ScPCA object>` for more details on working with these objects.
 
 
 ## Which projects can I download as merged objects?
@@ -248,3 +248,11 @@ We currently do not support including both data formats at once in `My Dataset`.
 Once a sample or project of a given data format has been added to `My Dataset`, all subsequent single-cell or single-nuclei data added will automatically be in that same format.
 
 Therefore, if you wish to download single-cell or single-nuclei expression data in both `SingleCellExperiment` and `AnnData` data formats, you will need to create and download separate `My Dataset`s, one at a time, for each format.
+
+## Why can't I merge a subset of samples from a project?
+
+{ref}`Merged project downloads<download_files:Merged object downloads>` are not available for a subset of samples in a project.
+Merged objects will always contain all samples in the given project ([see which projects do not have merged objects](#which-projects-can-i-download-as-merged-objects)).
+
+If you would like to work with a merged object that only contains a subset of project samples, we recommend downloading the merged object and subsetting it directly to the samples of your choosing.
+See {ref}`Subsetting the Merged Object<getting_started:Subsetting the merged object>` for instructions on how to subset `SingleCellExperiment` and `AnnData` merged objects.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -397,7 +397,7 @@ libraries <- c("SCPCL00000X", "SCPCL00000Y", "SCPCL00000Z")
 subsetted_merged_sce <- merged_sce[,merged_sce$library_id %in% libraries]
 ```
 
-To subset an `AnnData` merged object to a given set of libraries, use the following R code:
+To subset an `AnnData` merged object to a given set of libraries, use the following python code:
 
 ```r
 # Define list of library IDs of interest
@@ -408,7 +408,7 @@ subsetted_adata_merged_object = adata_merged_object[adata_merged_object.obs["lib
 ```
 
 The merged object additionally contains metadata such as information about sample diagnosis, subdiagnosis, or tissue location that may be useful for subsetting.
-A full set of merged object contents which can support subsetting is available in <TODO: the forthcoming section forthcoming in `merged_objects.md` about file contents>.
+A full set of merged object contents which can support subsetting {ref}`is available here<merged_objects:SingleCellExperiment cell metrics>`.
 
 As one example, to subset a `SingleCellExperiment` merged object to a given diagnosis, use the following R code:
 


### PR DESCRIPTION
Closes #399 

This PR adds an FAQ that you can't get a merged object for a subset of samples. I link to the getting started docs that explain how to subset a merged object as our recommendation instead. Let me know if you think there are any other details or relative links to include.

I also caught a couple things to fix in `getting_started.md` while I was here!