### PR TITLE
FAQ: project options changed after appending

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -260,7 +260,7 @@ See {ref}`Subsetting the Merged Object<getting_started:Subsetting the merged obj
 
 ## Why did project options change when I appended samples to My Dataset?
 
-If you would like to include samples from a dataset you have previously created, you can append these samples to your current `My Dataset`.
+If you would like to include all samples from a dataset you have previously created, you can append these samples to your current `My Dataset`.
 In some cases, however, certain project-level options may change when you append additional samples from a project that is already present in `My Dataset`.
 
 Specifically, we apply these rules when you append to `My Dataset`:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -260,7 +260,7 @@ See {ref}`Subsetting the Merged Object<getting_started:Subsetting the merged obj
 
 ## Why did project options change when I appended samples to My Dataset?
 
-It is possible append samples from a dataset you previously created in the past to your current `My Dataset`.
+If you would like to include samples from a dataset you have previously created, you can append these samples to your current `My Dataset`.
 In some cases, however, certain project-level options may change when you append additional samples from a project that is already present in `My Dataset`.
 
 Specifically, we apply these rules when you append to `My Dataset`:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -268,3 +268,5 @@ Specifically, we apply these rules when you append to `My Dataset`:
 * If you selected to {ref}`include bulk RNA-seq expression in the download<download_options:Modalities>` *either* in the previous dataset or the current `My Dataset`, bulk expression will remain included in the download.
 * If you selected the {ref}`merged project option<download_options:Merged objects>` **both** in the previous dataset and the current `My Dataset`, the merge option will remain selected.
 Otherwise, if only one dataset had this option selected, the merge option will no longer be applied.
+
+You are always welcome to edit these options in `My Dataset` to your liking after appending the additional samples.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -256,3 +256,15 @@ Merged objects will always contain all samples in the given project ([see which 
 
 If you would like to work with a merged object that only contains a subset of project samples, we recommend downloading the merged object and subsetting it directly to the samples of your choosing.
 See {ref}`Subsetting the Merged Object<getting_started:Subsetting the merged object>` for instructions on how to subset `SingleCellExperiment` and `AnnData` merged objects.
+
+
+## Why did project options change when I appended samples to My Dataset?
+
+It is possible append samples from a dataset you previously created in the past to your current `My Dataset`.
+In some cases, however, certain project-level options may change when you append additional samples from a project that is already present in `My Dataset`.
+
+Specifically, we apply these rules when you append to `My Dataset`:
+
+* If you selected to {ref}`include bulk RNA-seq expression in the download<download_options:Modalities>` *either* in the previous dataset or the current `My Dataset`, bulk expression will remain included in the download.
+* If you selected the {ref}`merged project option<download_options:Merged objects>` **both** in the previous dataset and the current `My Dataset`, the merge option will remain selected.
+Otherwise, if only one dataset had this option selected, the merge option will no longer be applied.


### PR DESCRIPTION
Closes #400
*formerly **Stacked on #420**
 
This PR adds an FAQ section about when project options change when appending more samples. I based it off of this section of our Slab notes which describes rules: https://data-lab-knowledge.slab.com/posts/list-of-cart-related-doc-changes-j1e56gnm#hleq5-appending-to-my-dataset-and-how-we-decide-to-apply-project-options

I'm going to request reviews from both @allyhawkins  and @dvenprasad for this one, since I really want to make sure my language is precise!