### PR TITLE
FAQ for regenerating datasets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ As of November 2023, the `CHANGELOG` is a feature of our documentation we'll use
 You can find more information about how and when your download was prepared in the following places:
 
 * The date your download was packaged (`Generated on: {date}`) is included at the top of the README in your download.
-* The version of the [`AlexsLemonade/scpca-nf`](https://github.com/alexsLemonade/scpca-nf) pipeline used to process data in your download is included in the `workflow_version` column of the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file in your download.
+* The version of the [`AlexsLemonade/scpca-nf`](https://github.com/alexsLemonade/scpca-nf) pipeline used to process data in your download is included in the `workflow_version` column of the `single_cell_metadata.tsv`, `bulk_metadata.tsv`, or `spatial_metadata.tsv` file in your download.
 For more information about `AlexsLemonade/scpca-nf` versions, please see [the releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 <!-------------------------------------------------->
@@ -14,11 +14,11 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 
 ## 2025.04.24
 
-* Consensus cell type annotations are now available in all processed `SingleCellExperiment` and `AnnData` objects and merged objects. 
-  * The labels obtained from `SingleR` and `CellAssign` are used to assign an ontology-aware consensus cell type label. 
-  * See our {ref}`documentation on cell type annotation<processing_information:cell type annotation>` to learn more about how consensus cell types are assigned. 
+* Consensus cell type annotations are now available in all processed `SingleCellExperiment` and `AnnData` objects and merged objects.
+  * The labels obtained from `SingleR` and `CellAssign` are used to assign an ontology-aware consensus cell type label.
+  * See our {ref}`documentation on cell type annotation<processing_information:cell type annotation>` to learn more about how consensus cell types are assigned.
   * See {ref}`the single-cell gene expression file contents page<sce_file_contents:singlecellexperiment cell metrics>` and {ref}`the merged object file contents page<merged_objects:singlecellexperiment cell metrics>` for more information on obtaining these cell type annotations from the downloaded objects.
-* All assays within a merged object are now saved as a sparse matrix (`CsparseMatrix`), whereas previously these assays were saved as a `DelayedArray`. 
+* All assays within a merged object are now saved as a sparse matrix (`CsparseMatrix`), whereas previously these assays were saved as a `DelayedArray`.
 
 ## 2024.11.14
 

--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -95,19 +95,19 @@ Every download also includes the individual [QC report](#qc-report) and, if appl
 
 ## Portal-wide Downloads
 
-The Portal-wide Download page can be used to download all [metadata](#metadata-only-downloads) or gene expression data for all samples on the Portal at once. 
+The Portal-wide Download page can be used to download all [metadata](#metadata-only-downloads) or gene expression data for all samples on the Portal at once.
 
-All single-cell and single-nuclei gene expression data from the Portal can be downloaded as a single zip file containing data stored as either [`SingleCellExperiment` objects (`.rds` files)](#singlecellexperiment-portal-wide-download-structure) or [`AnnData` objects (`.h5ad` files)](#anndata-portal-wide-download-structure). 
-All spatial data for any samples sequenced using [spatial transcriptomics](#spatial-transcriptomics-libraries) is available separately as a zip file. 
+All single-cell and single-nuclei gene expression data from the Portal can be downloaded as a single zip file containing data stored as either [`SingleCellExperiment` objects (`.rds` files)](#singlecellexperiment-portal-wide-download-structure) or [`AnnData` objects (`.h5ad` files)](#anndata-portal-wide-download-structure).
+All spatial data for any samples sequenced using [spatial transcriptomics](#spatial-transcriptomics-libraries) is available separately as a zip file.
 
-When downloading any of the available Portal-wide data downloads, all metadata and bulk RNA-seq data is also included. 
+When downloading any of the available Portal-wide data downloads, all metadata and bulk RNA-seq data is also included.
 
 <!--TODO: make sure data format naming for files is correctly formatted-->
 Each zip file will be named with the chosen data format (either `SingleCellExperiment` or `AnnData`) and the date you accessed the data on the ScPCA Portal.
 Each zip file will contain a folder for each project with gene expression data for all samples in that project as either individual objects or a single [merged object](#portal-wide-downloads-as-merged-objects), depending on your selection.
 
 As with [individual project](#project-downloads) and [custom datasets](#custom-datasets), the quantified CITE-seq expression data will be included when downloading single-cell expression data.
-For [`SingleCellExperiment (R)` downloads](#singlecellexperiment-portal-wide-download-structure), the quantified CITE-seq expression is included in the same file as the gene expression data. 
+For [`SingleCellExperiment (R)` downloads](#singlecellexperiment-portal-wide-download-structure), the quantified CITE-seq expression is included in the same file as the gene expression data.
 For [`AnnData (Python)` downloads](#anndata-portal-wide-download-structure), the quantified CITE-seq expression data is included as a separate file with the suffix `_adt.h5ad`.
 
 <!--TODO: Update images-->
@@ -123,9 +123,9 @@ spatial section to be moved here
 
 ### Portal-wide downloads as merged objects
 
-You can choose to download all single-cell and single-nuclei samples from the Portal as [merged objects for each project](#merged-object-downloads) by checking "Merge samples into one object per project". 
+You can choose to download all single-cell and single-nuclei samples from the Portal as [merged objects for each project](#merged-object-downloads) by checking "Merge samples into one object per project".
 {ref}`Merged objects<merged_objects:Merged objects>` contain gene expression for all samples in a given project in a single file.
-This download includes a folder for each project that contains a single merged object (`SCPCP000000_merged.rds` or `SCPCP000000_merged.h5ad`), a merged summary report (`SCPCP000000_merged-summary-report.html`), a single [metadata](#metadata) file (`single-cell_metadata.tsv`), and all individual [QC reports](#qc-report) and, if applicable, [cell type annotation reports](#cell-type-report) for each library included in the merged object for that project. 
+This download includes a folder for each project that contains a single merged object (`SCPCP000000_merged.rds` or `SCPCP000000_merged.h5ad`), a merged summary report (`SCPCP000000_merged-summary-report.html`), a single [metadata](#metadata) file (`single-cell_metadata.tsv`), and all individual [QC reports](#qc-report) and, if applicable, [cell type annotation reports](#cell-type-report) for each library included in the merged object for that project.
 
 Note that downloading all data using this option _will not_ download a merged object with all samples from all projects, but a single merged object for each project.
 
@@ -231,6 +231,9 @@ Each row corresponds to a unique sample/library combination and contains the fol
 | `demux_method` | Methods used to calculate demultiplexed sample numbers. Only present for multiplexed libraries |
 | `demux_samples` | Samples included in multiplexed library. Only present for multiplexed libraries |
 | `date_processed` | Date sample was processed through `AlexsLemonade/scpca-nf` |
+| `workflow` | The URL to the `AlexsLemonade/scpca-nf` workflow |
+| `workflow_version` | Version of `AlexsLemonade/scpca-nf` the sample was processed with |
+| `workflow_commit` | Commit hash of `AlexsLemonade/scpca-nf` the sample was processed with |
 
 Project-specific metadata will contain all columns listed in the table above and any additional project-specific columns, such as treatment or outcome.
 Metadata pertaining to processing will be available in this table and inside of the `SingleCellExperiment` and `AnnData` objects.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -273,10 +273,10 @@ You are always welcome to edit these options in `My Dataset` to your liking afte
 
 ## Why are some values different after I regenerate My Dataset?
 
-The Portal only offers data processed using a single version of the `scpca-nf` workflow for each sample at any given time.
-If any new features or updates are made to the processing workflow, all data currently on the Portal will be re-processed.
+The Portal only offers data processed using a single version of the [`scpca-nf` workflow](github.com/AlexsLemonade/scpca-nf/) for each sample at any given time.
+If any new features or updates are made to the `scpca-nf` workflow, all data currently on the Portal will be re-processed.
 Because of this, when you regenerate a previously-created version of `My Dataset`, the values in your downloaded files may be slightly different compared to a previous download.
-A full description of any major changes made to data on the Portal are described in the {ref}`CHANGELOG page<changelog:CHANGELOG>`. 
+A full description of any major changes made to data on the Portal are described in the {ref}`CHANGELOG page<changelog:CHANGELOG>`.
 
 You can learn more about the specific version of the data you have as follows:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -282,6 +282,6 @@ You can learn more about the specific version of the data you have as follows:
 * The file name of each downloaded zip file, and the enclosed `README.md`, will include the date it was downloaded from the Portal
 * The {ref}`CHANGELOG page<changelog:CHANGELOG>` provides information about data changes within the Portal
 * The metadata included in your downloaded files will contain information about the `scpca-nf` workflow version that was used to process the data
-  * For example, the column `workflow_version` in the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file included in your download provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample, and the column `processed_date` provides the date the sample was processed through the workflow.
+  * For example, the column `workflow_version` in the metadata file included in your download (`single_cell_metadata.tsv`, `bulk_metadata.tsv`, and/or `spatial_metadata.tsv`) provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample, and the column `processed_date` provides the date the sample was processed through the workflow.
   See the {ref}`metadata documentation<download_files:metadata> for additional information
 * For more information about a given `scpca-nf` release, refer to the [workflow release notes](https://github.com/AlexsLemonade/scpca-nf/releases)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -273,13 +273,14 @@ You are always welcome to edit these options in `My Dataset` to your liking afte
 
 ## Why are some values different after I regenerate My Dataset?
 
-The Portal only offers one version of each sample at any given time.
+The Portal only offers data processed using a single version of the `scpca-nf` workflow for each sample at any given time.
+If any new features or updates are made to the processing workflow, all data currently on the Portal will be re-processed.
 Because of this, when you regenerate a previously-created version of `My Dataset`, the values in your downloaded files may be slightly different compared to a previous download.
+A full description of any major changes made to data on the Portal are described in the {ref}`CHANGELOG page<changelog:CHANGELOG>`. 
 
 You can learn more about the specific version of the data you have as follows:
 
 * The file name of each downloaded zip file, and the enclosed `README.md`, will include the date it was downloaded from the Portal
-* The {ref}`CHANGELOG page<changelog:CHANGELOG>` provides information about data changes within the Portal
 * The metadata included in your downloaded files will contain information about the `scpca-nf` workflow version that was used to process the data
   * For example, the column `workflow_version` in the metadata file included in your download (`single_cell_metadata.tsv`, `bulk_metadata.tsv`, and/or `spatial_metadata.tsv`) provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample, and the column `processed_date` provides the date the sample was processed through the workflow.
   See the {ref}`metadata documentation<download_files:metadata>` for additional information

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -282,5 +282,5 @@ You can learn more about the specific version of the data you have as follows:
 * The {ref}`CHANGELOG page<changelog:CHANGELOG>` provides information about data changes within the Portal
 * The metadata included in your downloaded files will contain information about the `scpca-nf` workflow version that was used to process the data
   * For example, the column `workflow_version` in the metadata file included in your download (`single_cell_metadata.tsv`, `bulk_metadata.tsv`, and/or `spatial_metadata.tsv`) provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample, and the column `processed_date` provides the date the sample was processed through the workflow.
-  See the {ref}`metadata documentation<download_files:metadata> for additional information
+  See the {ref}`metadata documentation<download_files:metadata>` for additional information
 * For more information about a given `scpca-nf` release, refer to the [releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -275,7 +275,6 @@ You are always welcome to edit these options in `My Dataset` to your liking afte
 
 The Portal only offers one version of each sample at any given time.
 Because of this, when you regenerate a previously-created version of `My Dataset`, the values in your downloaded files may be slightly different compared to a previous download.
-The file name of each downloaded zip file, and the enclosed `README.md`, will include the date it was downloaded from the Portal
 
 You can learn more about the specific version of the data you have as follows:
 
@@ -284,4 +283,4 @@ You can learn more about the specific version of the data you have as follows:
 * The metadata included in your downloaded files will contain information about the `scpca-nf` workflow version that was used to process the data
   * For example, the column `workflow_version` in the metadata file included in your download (`single_cell_metadata.tsv`, `bulk_metadata.tsv`, and/or `spatial_metadata.tsv`) provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample, and the column `processed_date` provides the date the sample was processed through the workflow.
   See the {ref}`metadata documentation<download_files:metadata> for additional information
-* For more information about a given `scpca-nf` release, refer to the [workflow release notes](https://github.com/AlexsLemonade/scpca-nf/releases)
+* For more information about a given `scpca-nf` release, refer to the [releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -273,15 +273,15 @@ You are always welcome to edit these options in `My Dataset` to your liking afte
 
 ## Why are some values different after I regenerate My Dataset?
 
-The Portal only offers data processed using a single version of the [`scpca-nf` workflow](github.com/AlexsLemonade/scpca-nf/) for each sample at any given time.
-If any new features or updates are made to the `scpca-nf` workflow, all data currently on the Portal will be re-processed.
+The Portal only offers data processed using a single version of the [`AlexsLemonade/scpca-nf` workflow](github.com/AlexsLemonade/scpca-nf/) for each sample at any given time.
+If any new features or updates are made to the workflow, all data currently on the Portal will be re-processed.
 Because of this, when you regenerate a previously-created version of `My Dataset`, the values in your downloaded files may be slightly different compared to a previous download.
 A full description of any major changes made to data on the Portal are described in the {ref}`CHANGELOG page<changelog:CHANGELOG>`.
 
 You can learn more about the specific version of the data you have as follows:
 
 * The file name of each downloaded zip file, and the enclosed `README.md`, will include the date it was downloaded from the Portal
-* The metadata included in your downloaded files will contain information about the `scpca-nf` workflow version that was used to process the data
+* The metadata included in your downloaded files will contain information about the `AlexsLemonade/scpca-nf` workflow version that was used to process the data
   * For example, the column `workflow_version` in the metadata file included in your download (`single_cell_metadata.tsv`, `bulk_metadata.tsv`, and/or `spatial_metadata.tsv`) provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample, and the column `processed_date` provides the date the sample was processed through the workflow.
   See the {ref}`metadata documentation<download_files:metadata>` for additional information
-* For more information about a given `scpca-nf` release, refer to the [releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases)
+* For more information about a given `AlexsLemonade/scpca-nf` release, refer to the [releases page on GitHub](https://github.com/AlexsLemonade/scpca-nf/releases)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -270,3 +270,18 @@ Specifically, we apply these rules when you append to `My Dataset`:
 Otherwise, if only one dataset had this option selected, the merge option will no longer be applied.
 
 You are always welcome to edit these options in `My Dataset` to your liking after appending the additional samples.
+
+## Why are some values different after I regenerate My Dataset?
+
+The Portal only offers one version of each sample at any given time.
+Because of this, when you regenerate a previously-created version of `My Dataset`, the values in your downloaded files may be slightly different compared to a previous download.
+The file name of each downloaded zip file, and the enclosed `README.md`, will include the date it was downloaded from the Portal
+
+You can learn more about the specific version of the data you have as follows:
+
+* The file name of each downloaded zip file, and the enclosed `README.md`, will include the date it was downloaded from the Portal
+* The {ref}`CHANGELOG page<changelog:CHANGELOG>` provides information about data changes within the Portal
+* The metadata included in your downloaded files will contain information about the `scpca-nf` workflow version that was used to process the data
+  * For example, the column `workflow_version` in `single_cell_metadata.tsv` or `bulk_metadata.tsv` file in your download provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample.
+  See the {ref}`metadata documentation<download_files:metadata> for additional information
+* For more information about a given `scpca-nf` release, refer to the [workflow release notes](https://github.com/AlexsLemonade/scpca-nf/releases)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -282,6 +282,6 @@ You can learn more about the specific version of the data you have as follows:
 * The file name of each downloaded zip file, and the enclosed `README.md`, will include the date it was downloaded from the Portal
 * The {ref}`CHANGELOG page<changelog:CHANGELOG>` provides information about data changes within the Portal
 * The metadata included in your downloaded files will contain information about the `scpca-nf` workflow version that was used to process the data
-  * For example, the column `workflow_version` in `single_cell_metadata.tsv` or `bulk_metadata.tsv` file in your download provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample.
+  * For example, the column `workflow_version` in the `single_cell_metadata.tsv` or `bulk_metadata.tsv` file included in your download provides the `AlexsLemonade/scpca-nf` workflow version used to process the sample, and the column `processed_date` provides the date the sample was processed through the workflow.
   See the {ref}`metadata documentation<download_files:metadata> for additional information
 * For more information about a given `scpca-nf` release, refer to the [workflow release notes](https://github.com/AlexsLemonade/scpca-nf/releases)


### PR DESCRIPTION
Closes #401
Stacked on #421

This PR adds a section on regenerating datasets to explain that only one version is available at a time as well as information about how to learn more about what version has been downloaded. Again, I'm going to request 2x review here to be sure on phrasing and scope!

While I was here, I also realized a couple other things to fix:
- The columns with workflow information had not been documented as metadata columns, so I went ahead and did that
- The associated text at the top of the CHANGELOG file did not indicate that this info is available in the spatial metadata file, but I confirmed that it is, so I went ahead and updated that text too