### PR TITLE
Clean up stubs and todos for cart documentation

### DIFF
--- a/docs/download_files.md
+++ b/docs/download_files.md
@@ -43,6 +43,7 @@ See the [section on bulk RNA-seq for more information](#bulk-rna-seq).
 See the expected file structure and [description of the Spatial transcriptomics output below](#spatial-transcriptomics-libraries).
 - If the project contains samples that have been multiplexed, the organization of the downloaded files will be slightly different than what is shown below. 
 See the section describing [multiplexed sample libraries](#multiplexed-sample-libraries) for an overview of the expected download structure. 
+
 For more information on choosing a data format and modality, see the {ref}`documentation on download options<download_options:Download options>`.
 
 When downloading a project, you can choose to download data from all samples as individual files, or you can download {ref}`a single file containing all samples merged into a single object<faq:When should I download a project as a merged object?>`.
@@ -161,7 +162,7 @@ Note that downloading all data using this option _will not_ download a merged ob
 ![portal wide download structure - merged `sce`](images/portal-wide-sc-merged.png){width="600"}
 
 #### Portal-wide download structure for merged `AnnData` objects
-![portal wide download structure - merged `anndata`](iamges/portal-wide-anndata-cite-seq-merged.png){width="600"}
+![portal wide download structure - merged `anndata`](images/portal-wide-anndata-cite-seq-merged.png){width="600"}
 
 ### Metadata-only downloads
 
@@ -308,10 +309,8 @@ Inside that folder will be the following folders and files:
 
 A full description of all files included in the download for spatial transcriptomics libraries can also be found in the [`spaceranger count` documentation](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/using/count#outputs).
 
-<!-- TODO: Confirm spatial_metadata.tsv or spatial-metadata.tsv: https://github.com/AlexsLemonade/scpca-docs/issues/381#issuecomment-2867277605 -->
 Every download also includes a single `spatial_metadata.tsv` file containing metadata for all libraries included in the download.
 
-<!--TODO: update this image to have correct folder names-->
 ![sample download with spatial](images/project-spatial.png){width="600"}
 
 

--- a/docs/download_options.md
+++ b/docs/download_options.md
@@ -32,20 +32,18 @@ Selecting `Spatial` will provide you with the spatial transcriptomic data only.
 If you are creating a custom dataset that contains samples and/or projects with bulk RNA-seq data, you will have the option to include this data in your download as well.
 Note that the bulk RNA-seq expression file will always include all samples from the given project with bulk expression, even if you are only downloading a subset of that project's samples.
 If you are using the "Download now" button to download a full project that contains bulk RNA-seq expression, it will automatically be included with the download.
-<!-- TODO: Confirm if there are any Spatial considerations here we need to add:
-https://github.com/AlexsLemonade/scpca-docs/pull/413#issuecomment-2867497722 -->
 
-For more information about the expected file download structure for `Single-cell` and `Spatial` modalities, refer to our {ref}`Downloadable files<download_files:STUB LINK TO SECTION WITH SINGLE-CELL/SPATIAL DOWNLOAD FOLDERS>`.
+For more information about the expected file download structure for `Single-cell` and `Spatial` modalities, refer to our {ref}`Downloadable files<download_files:Project downloads>`.
 
 ## Merged objects
 
 When downloading a project, either by using `Download Now` or `Add to Dataset`, you will have the option to either receive the data as objects for individual libraries, or as {ref}`a single merged object with data from all samples in the given project<merged_objects:Merged objects>`.
 Please be aware that merged objects have _not_ been integrated or batch-corrected.
-Refer to {ref}`this documentation<download_files:Merged object downloads` for the contents of a merged object download specifically.
+Refer to {ref}`this documentation<download_files:Merged object downloads>` for the contents of a merged object download specifically.
 Note that this applies only to `Single-cell` modality downloads, not `Spatial`.
 
 When {ref}`creating a custom dataset to download<download_files:Custom datasets>`, you will be able to select the option to merge all samples only if you have included all samples from the given project in `My Dataset`.
-Merging a subset of samples in a project {ref}`is not currently supported<faq:STUB for https://github.com/AlexsLemonade/scpca-docs/issues/399>`.
+Merging a subset of samples in a project {ref}`is not currently supported<faq.md:Why can't I merge a subset of samples from a project?>`.
 In addition, merged objects are not available for all samples or projects, {ref}`as described here <faq:Which projects can I download as merged objects?>`.
 
 Note that even when {ref}`downloading data for all single-cell and single-nuclei samples on the Portal<download_files:Portal-wide downloads>`, merged objects will still be provided per-project.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -220,6 +220,14 @@ There are three types of projects for which merged objects are not available:
     - The more samples that are included in a merged object, the larger the object, and the more difficult it will be to work with that object in R or Python.
     Because of this, we do not provide merged objects for projects with more than 100 samples as the size of the merged object is too large.
 
+## Why can't I merge a subset of samples from a project?
+
+{ref}`Merged project downloads<download_files:Merged object downloads>` are not available for a subset of samples in a project.
+Merged objects will always contain all samples in the given project ([see which projects do not have merged objects](#which-projects-can-i-download-as-merged-objects)).
+
+If you would like to work with a merged object that only contains a subset of project samples, we recommend downloading the merged object and subsetting it directly to the samples of your choosing.
+See {ref}`Subsetting the Merged Object<getting_started:Subsetting the merged object>` for instructions on how to subset `SingleCellExperiment` and `AnnData` merged objects.
+
 ## Why doesn't my existing code work on a new download from the Portal?
 
 Although we try to maintain backward compatibility, new features added to the ScPCA Portal may result in downloads that are no longer compatible with code written with older downloads from the ScPCA Portal in mind.
@@ -248,14 +256,6 @@ We currently do not support including both data formats at once in `My Dataset`.
 Once a sample or project of a given data format has been added to `My Dataset`, all subsequent single-cell or single-nuclei data added will automatically be in that same format.
 
 Therefore, if you wish to download single-cell or single-nuclei expression data in both `SingleCellExperiment` and `AnnData` data formats, you will need to create and download separate `My Dataset`s, one at a time, for each format.
-
-## Why can't I merge a subset of samples from a project?
-
-{ref}`Merged project downloads<download_files:Merged object downloads>` are not available for a subset of samples in a project.
-Merged objects will always contain all samples in the given project ([see which projects do not have merged objects](#which-projects-can-i-download-as-merged-objects)).
-
-If you would like to work with a merged object that only contains a subset of project samples, we recommend downloading the merged object and subsetting it directly to the samples of your choosing.
-See {ref}`Subsetting the Merged Object<getting_started:Subsetting the merged object>` for instructions on how to subset `SingleCellExperiment` and `AnnData` merged objects.
 
 
 ## Why did project options change when I appended samples to My Dataset?


### PR DESCRIPTION
Closes #412 

I went through the updates to download options, download files, and FAQs and caught a few places with stub links that needed to be updated and removed any TODOs. 

- All stub links should now be updated. I also caught a few links that were broken and fixed those. 
- I removed any remaining TODOs since those had been addressed. 
- I fixed a link to one of the images that was broken. 
- I moved the new FAQ about merging parts of a project to be grouped with the other merged FAQs. 