### PR TITLE
Changelog entry about merged objects bug fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,11 @@ For more information about `AlexsLemonade/scpca-nf` versions, please see [the re
 <!-- PUT THE NEW CHANGELOG ENTRY RIGHT BELOW THIS -->
 <!-------------------------------------------------->
 
+## TODO: UPDATE WITH CORRECT DATE
+
+* Previously, the `cell_id` column in the cell metadata for merged objects was incorrectly formatted.  
+This has now been fixed so that all merged objects have the `cell_id` formatted as `<library_id>-<barcode>`. 
+
 ## 2025.04.24
 
 * Consensus cell type annotations are now available in all processed `SingleCellExperiment` and `AnnData` objects and merged objects. 


### PR DESCRIPTION
Closes #432 

Here I'm adding in the changelog entry needed to account for the bug fix in the merged objects. I will keep this in a draft state until we are ready to update the objects on the Portal and then I can update the date. 

Once this goes in, we will need to merge this branch (with the correct date) into `development`. 