### PR TITLE
Turn on spell check

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,12 +1,12 @@
 name: Spell check Markdown files
 
 # Controls when the action will run.
-# Pull requests to master only.
 on:
   pull_request:
     branches:
       - main
       - development
+      - "the-manuscript"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
In this PR I'm adding `the-manuscript` to the branches where the spell check action should be run. I'm pretty sure this will work to send this PR directly to `the-manuscript` branch (as in I don't think it needs to be committed to in `main`), but in case I'm wrong we'll find out soon enough as PRs come in :) 
I put it in quotes too, since don't know about that dash. 