### PR TITLE
Update "uns" docs to explain excluded fields

### DIFF
--- a/docs/sce_file_contents.md
+++ b/docs/sce_file_contents.md
@@ -450,7 +450,7 @@ There are two exceptions to this:
 
 * The `AnnData` object does not contain the `sample_metadata` item in the `.uns` slot.
 Instead, the contents of the `sample_metadata` data frame are stored in the cell-level metadata (`.obs`).
-* The `AnnData` object does not contain any metadata fields whose object type could not be converted to python.
+* The `AnnData` object does not contain any metadata fields whose type could not be automatically converted to a Python object.
 This includes any `list` type fields present in the `SingleCellExperiment` metadata.
 
 


### PR DESCRIPTION
This PR is a companion PR to https://github.com/AlexsLemonade/scpcaTools/pull/322 (hence my choice of reviewer!).

It turns out that the current docs didn't actually mention yet anything about fields that are missing from anndata `.uns` slot but present in SCE metadata. So, I got to add it in! I rephrased a smidge to include a bullet point that says the `uns` is missing any metadata that couldn't be converted to python, but I don't actually state the name of those fields. I did, however, update the metadata table to indicate that it's a `DataFrame` to help traceability. 

Let me know if you think the level of detail here should shift at all!