### PR TITLE
Update citation to use Cell Genomics publication

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -41,6 +41,7 @@ fastp
 FASTQ
 Franzén
 GC
+Genom
 Genomics
 github
 GRCh

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -16,6 +16,6 @@ Please consider contacting the project contact (also available on the project pa
 
 ## Citing the ScPCA Portal
 
-When citing the ScPCA Portal, please cite the following preprint:
+When citing the ScPCA Portal, please cite the following publication:
 
-Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2026 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. Cell Genom. 6:101283. https://doi.org/10.1016/j.xgen.2026.101283


### PR DESCRIPTION
Closes #510 

I just updated the citation we list to include the publication in Cell Genomics. I'm filing this to `development`, but if we want to get this updated on the Portal ASAP, I can file the same change to `main` and then do a release. 